### PR TITLE
start logger to keep Logger.debug from crashing the Daemon

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule MuonTrap.MixProject do
   end
 
   def application do
-    []
+    [extra_applications: [:logger]]
   end
 
   defp deps() do


### PR DESCRIPTION
When Logger is not started and I try to run: `MuonTrap.Daemon.start_link` the process crashes.

```
iex(1)> {:ok, pid} = MuonTrap.Daemon.start_link("echo", ["hello world"])
{:ok, #PID<0.188.0>}
iex(2)> 
=ERROR REPORT==== 8-Mar-2018::15:29:36 ===
** Generic server <0.188.0> terminating 
** Last message in was {#Port<0.7346>,{data,"hello world\n"}}
** When Server state == #{'__struct__' => 'Elixir.MuonTrap.Daemon.State',
                          command => <<"echo">>,group => nil,
                          port => #Port<0.7346>}
** Reason for termination == 
** {#{'__exception__' => true,'__struct__' => 'Elixir.RuntimeError',
      message =>
          <<"cannot use Logger, the :logger application is not running">>},
    [{'Elixir.Logger.Config','__data__',0,
                             [{file,"lib/logger/config.ex"},{line,53}]},
     {'Elixir.Logger',bare_log,3,[{file,"lib/logger.ex"},{line,613}]},
     {'Elixir.MuonTrap.Daemon',handle_info,2,
                               [{file,"lib/muontrap/daemon.ex"},{line,75}]},
     {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,616}]},
     {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,686}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
** (EXIT from #PID<0.186.0>) shell process exited with reason: an exception was raised:
    ** (RuntimeError) cannot use Logger, the :logger application is not running
        (logger) lib/logger/config.ex:53: Logger.Config.__data__/0
        (logger) lib/logger.ex:613: Logger.bare_log/3
        (muontrap) lib/muontrap/daemon.ex:75: MuonTrap.Daemon.handle_info/2
        (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
        (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
        (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
        
```

By starting Logger, there is no longer a crash like so:

```
iex(1)> {:ok, pid} = MuonTrap.Daemon.start_link("echo", ["hello world"]) 
{:ok, #PID<0.598.0>}
iex(2)> 
15:29:02.622 [debug] MuonTrap.Daemon ignoring output from echo: 'hello world\n'
```