### PR TITLE
add redirecting stderr to stdout for deamon process

### DIFF
--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -21,6 +21,7 @@ defmodule MuonTrap.Daemon do
   The same options as `MuonTrap.cmd/3` are available with the following additions:
 
   * {`log_output`, level} - Logs anything that the command sends to stdout
+  * {`stderr_to_stdout`, boolean} - If `true` redirect stderr to stdout, default `false`
   """
 
   defmodule State do
@@ -74,7 +75,10 @@ defmodule MuonTrap.Daemon do
   def init([command, args, opts]) do
     group = Keyword.get(opts, :group)
     logging = Keyword.get(opts, :log_output)
-    opts = Keyword.drop(opts, [:log_output])
+    stderr_to_stdout = Keyword.get(opts, :stderr_to_stdout, false)
+    opts = Keyword.drop(opts, [:log_output, :stderr_to_stdout])
+
+    opts = add_stderr_to_stdout(opts, stderr_to_stdout)
 
     {muontrap_args, leftover_opts} = Options.to_args(opts)
     updated_args = muontrap_args ++ ["--", command] ++ args
@@ -117,4 +121,7 @@ defmodule MuonTrap.Daemon do
     _ = Logger.error("#{state.command}: Process exited with status #{status}")
     {:stop, :normal, state}
   end
+
+  defp add_stderr_to_stdout(opts, true), do: [:stderr_to_stdout | opts]
+  defp add_stderr_to_stdout(opts, false), do: opts
 end

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -44,4 +44,16 @@ defmodule DaemonTest do
 
     refute capture_log(fun) =~ "hello"
   end
+
+  test "daemon logs output to stderr when told" do
+    opts = [log_output: :error, stderr_to_stdout: true]
+
+    fun = fn ->
+      {:ok, _pid} = GenServer.start(Daemon, ["test/echo_stderr.test", [], opts])
+      wait_for_close_check()
+      Logger.flush()
+    end
+
+    assert capture_log(fun) =~ "stderr message"
+  end
 end

--- a/test/echo_stderr.c
+++ b/test/echo_stderr.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main()
+{
+    fprintf(stderr, "stderr message\n");
+    sleep(1000000);
+    exit(0);
+}


### PR DESCRIPTION
fixes #4 

Having different log levels is only possible with something more advanced like `erlexec`.
Parsing with the existing parsing is not possible since `System.cmd` does expect a tuple for `stderr_to_stdout`, whereas `Port.open` falls back on the Erlang options.