### PR TITLE
 Set Daemon exit reason based on exit status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - mix deps.get
   - mix compile
   - mix test
-  - if [ "$COVERALLS" = "true" ]; then MIX_ENV=test mix coveralls.circle; fi
+  - if [ "$COVERALLS" = "true" ]; then MIX_ENV=test mix coveralls.travis; fi
   - if [ "$DOCS" = "true"; then MIX_ENV=docs mix docs; fi
   - mix format --check-formatted
   - MIX_ENV=docs mix hex.build

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ For many long running programs, you may want to restart them if they crash.
 Luckily Erlang already has mechanisms to do this. `MuonTrap` provides a
 `GenServer` called `MuonTrap.Daemon` that you can hook into one of your
 supervision trees.  For example, you could specify it like this in your
-application's supervisor::
+application's supervisor:
 
 ```elixir
   def start(_type, _args) do
@@ -191,10 +191,28 @@ application's supervisor::
   end
 ```
 
-If part of the startup of your command involves an initialization sequence, you
-may want to manually  call `MuonTrap.Daemon.start_link/3` so that if anything
-happens to the command or your Elixir code that it gets restarted and
-reinitialized automatically.
+Supervisors provide three restart strategies, `:permanent`, `:temporary`, and
+`:transient`. They work as follows:
+
+* `:permanent` - Always restart the command if it exits or crashes. Restarts are
+  limited to the Supervisor's restart intensity settings as they would be with
+  normal `GenServer`s. This is the default.
+* `:transient` - If the exit status of the command is 0 (i.e., success), then
+  don't restart. Any other exit status is considered an error and the command is
+  restarted.
+* `:temporary` - Don't restart
+
+If you're running more than one `MuonTrap.Daemon` under the same `Supervisor`,
+then you'll need to give each one a unique `:id`. Here's an example `child_spec`
+for setting the `:id` and the `:restart` parameters:
+
+```elixir
+    Supervisor.child_spec(
+        {MuonTrap.Daemon, ["command", ["arg1"], options]},
+         id: :my_daemon,
+         restart: :transient
+      )
+```
 
 ## muontrap development
 

--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -150,8 +150,18 @@ defmodule MuonTrap.Daemon do
 
   @impl true
   def handle_info({port, {:exit_status, status}}, %State{port: port} = state) do
-    _ = Logger.error("#{state.command}: Process exited with status #{status}")
-    {:stop, :normal, state}
+    reason =
+      case status do
+        0 ->
+          _ = Logger.info("#{state.command}: Process exited successfully")
+          :normal
+
+        _failure ->
+          _ = Logger.error("#{state.command}: Process exited with status #{status}")
+          :error_exit_status
+      end
+
+    {:stop, reason, state}
   end
 
   defp add_stderr_to_stdout(opts, true), do: [:stderr_to_stdout | opts]

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -19,16 +19,6 @@ defmodule DaemonTest do
     assert_os_pid_exited(os_pid)
   end
 
-  test "exiting the process ends the daemon" do
-    assert capture_log(fn ->
-             {:ok, pid} =
-               start_supervised({Daemon, ["echo", ["hello"], [stderr_to_stdout: true]]})
-
-             wait_for_close_check()
-             refute Process.alive?(pid)
-           end) =~ "[error] echo: Process exited with status 0"
-  end
-
   test "daemon logs output when told" do
     fun = fn ->
       {:ok, _pid} =
@@ -87,5 +77,58 @@ defmodule DaemonTest do
     end
 
     assert capture_log(fun) =~ "MUONTRAP_TEST_VAR=HELLO_THERE"
+  end
+
+  test "transient daemon restarts on errored exits" do
+    # :transient means that successful exits don't restart, but
+    # failed exits do.
+
+    tempfile = Path.join("test", "tmp-transient_daemon")
+    _ = File.rm(tempfile)
+
+    log =
+      capture_log(fn ->
+        {:ok, _pid} =
+          start_supervised(
+            {Daemon, ["test/succeed_second_time.test", [tempfile], [log_output: :error]]},
+            restart: :transient
+          )
+
+        # Give it time to run twice if successful or more than twice if not.
+        Process.sleep(500)
+
+        Logger.flush()
+      end)
+
+    _ = File.rm(tempfile)
+
+    assert log =~ "Called 0 times"
+    assert log =~ "Called 1 times"
+    refute log =~ "Called 2 times"
+  end
+
+  test "permanent daemon always restarts" do
+    tempfile = Path.join("test", "tmp-permanent_deamon")
+    _ = File.rm(tempfile)
+
+    log =
+      capture_log(fn ->
+        {:ok, _pid} =
+          start_supervised(
+            {Daemon, ["test/succeed_second_time.test", [tempfile], [log_output: :error]]},
+            restart: :permanent
+          )
+
+        # Give it time to restart a few times.
+        Process.sleep(500)
+
+        Logger.flush()
+      end)
+
+    _ = File.rm(tempfile)
+
+    assert log =~ "Called 0 times"
+    assert log =~ "Called 1 times"
+    assert log =~ "Called 2 times"
   end
 end

--- a/test/succeed_second_time.c
+++ b/test/succeed_second_time.c
@@ -1,0 +1,40 @@
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static int read_counter(const char *filename)
+{
+    FILE *fp = fopen(filename, "r");
+    if (!fp)
+        return 0;
+
+    int counter;
+    if (fscanf(fp, "%d", &counter) != 1)
+        counter = 0;
+    fclose(fp);
+    return counter;
+}
+
+static void write_counter(const char *filename, int counter)
+{
+    FILE *fp = fopen(filename, "w");
+    fprintf(fp, "%d\n", counter);
+    fclose(fp);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+        errx(EXIT_FAILURE, "Pass a filename");
+
+    int counter = read_counter(argv[1]);
+    printf("Called %d times\n", counter);
+    write_counter(argv[1], counter + 1);
+
+    // Only exit successful on the second call.
+    if (counter == 1)
+        exit(EXIT_SUCCESS);
+    else
+        exit(EXIT_FAILURE);
+}


### PR DESCRIPTION
This makes it possible to use the `:transient` restart mode on
Supervisors where processes get restarted only if they stop due to
errors. An exit status of 0 exits with a `:normal` reason. Any other
exit status value does not.

Previously it was only possible to use `:permanent` (restart on every
exit) and `:temporary` (never restart).