### PR TITLE
Support custom prefixes when logging daemon output

### DIFF
--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -23,6 +23,7 @@ defmodule MuonTrap.Options do
   * `:env`
   * `:name` - `MuonTrap.Daemon`-only
   * `:log_output` - `MuonTrap.Daemon`-only
+  * `:log_prefix` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
   * `:cgroup_path`
   * `:cgroup_base`
@@ -101,6 +102,9 @@ defmodule MuonTrap.Options do
   defp validate_option(:daemon, {:log_output, level}, opts)
        when level in [:error, :warn, :info, :debug],
        do: Map.put(opts, :log_output, level)
+
+  defp validate_option(:daemon, {:log_prefix, prefix}, opts) when is_binary(prefix),
+    do: Map.put(opts, :log_prefix, prefix)
 
   # MuonTrap common options
   defp validate_option(_any, {:cgroup_controllers, controllers}, opts) when is_list(controllers),

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -63,6 +63,20 @@ defmodule DaemonTest do
     assert capture_log(fun) =~ "stderr message"
   end
 
+  test "daemon logs to a custom prefix" do
+    fun = fn ->
+      {:ok, _pid} =
+        start_supervised(
+          daemon_spec("echo", ["hello"], log_output: :error, log_prefix: "echo says: ")
+        )
+
+      wait_for_close_check()
+      Logger.flush()
+    end
+
+    assert capture_log(fun) =~ "echo says: hello"
+  end
+
   test "can pass environment variables to the daemon" do
     fun = fn ->
       {:ok, _pid} =


### PR DESCRIPTION
This adds a `:log_prefix` option so that instead of the normal "<command
path>:" prefixes, more or less information can be logged. The default is
still the old way.

This makes the logging output a lot easier to follow when the same
command is used in different contexts.