### PR TITLE
Change :delay_to_sigkill to use milliseconds

### DIFF
--- a/lib/muontrap.ex
+++ b/lib/muontrap.ex
@@ -53,7 +53,7 @@ defmodule MuonTrap do
     * `:cgroup_base` - create a temporary path under the specified cgroup path
     * `:cgroup_path` - explicitly specify a path to use. Use `:cgroup_base`, unless you must control the path.
     * `:cgroup_sets` - set a cgroup controller parameter before running the command
-    * `:delay_to_sigkill` - milliseconds before sending a SIGKILL to a child process if it doesn't exit with a SIGTERM
+    * `:delay_to_sigkill` - milliseconds before sending a SIGKILL to a child process if it doesn't exit with a SIGTERM (default 500 ms)
     * `:uid` - run the command using the specified uid or username
     * `:gid` - run the command using the specified gid or group
 

--- a/src/muontrap.c
+++ b/src/muontrap.c
@@ -387,7 +387,7 @@ static void cleanup_all_children()
     // The immediate child of muontrap will have either exited
     // at this point, so any other processes are orphaned descendents.
     // I.e., Their parent is now PID 1 and we won't get a SIGCHLD when
-    // they die. We only know who they are since they're in the cgruop.
+    // they die. We only know who they are since they're in the cgroup.
 
     // Send every child a SIGKILL
     int children_left = kill_children(SIGKILL);

--- a/src/muontrap.c
+++ b/src/muontrap.c
@@ -76,7 +76,7 @@ static void usage()
     printf("--controller,-c <cgroup controller> (may be specified multiple times)\n");
     printf("--group,-g <cgroup path>\n");
     printf("--set,-s <cgroup variable>=<value>\n (may be specified multiple times)\n");
-    printf("--delay-to-sigkill,-k <microseconds>\n");
+    printf("--delay-to-sigkill,-k <milliseconds>\n");
     printf("--uid <uid/user> drop privilege to this uid or user\n");
     printf("--gid <gid/group> drop privilege to this gid or group\n");
     printf("-- the program to run and its arguments come after this\n");
@@ -583,8 +583,7 @@ int main(int argc, char *argv[])
             exit(EXIT_SUCCESS);
 
         case 'k': // --delay-to-sigkill
-            // Specified in microseconds for legacy reasons
-            brutal_kill_wait_ms = strtoul(optarg, NULL, 0) / 1000;
+            brutal_kill_wait_ms = strtoul(optarg, NULL, 0);
             break;
 
         case 's':

--- a/test/muontrap_test.exs
+++ b/test/muontrap_test.exs
@@ -33,7 +33,7 @@ defmodule MuonTrapTest do
   end
 
   test "closing the port kills a process that ignores sigterm" do
-    port = run_muontrap(["--delay-to-sigkill", "1000", "test/ignore_sigterm.test"])
+    port = run_muontrap(["--delay-to-sigkill", "1", "test/ignore_sigterm.test"])
 
     os_pid = os_pid(port)
     assert_os_pid_running(os_pid)
@@ -44,7 +44,7 @@ defmodule MuonTrapTest do
   end
 
   test "delaying the SIGKILL" do
-    port = run_muontrap(["--delay-to-sigkill", "250000", "test/ignore_sigterm.test"])
+    port = run_muontrap(["--delay-to-sigkill", "250", "test/ignore_sigterm.test"])
 
     Process.sleep(10)
     os_pid = os_pid(port)

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -69,7 +69,7 @@ defmodule MuonTrap.OptionsTest do
       parallelism: true,
       uid: 5,
       gid: "bill",
-      delay_to_sigkill: 1000,
+      delay_to_sigkill: 1,
       env: [{"KEY", "VALUE"}, {"KEY2", "VALUE2"}],
       cgroup_controllers: ["memory", "cpu"],
       cgroup_base: "base",
@@ -85,7 +85,7 @@ defmodule MuonTrap.OptionsTest do
       assert Map.get(options, :parallelism) == true
       assert Map.get(options, :uid) == 5
       assert Map.get(options, :gid) == "bill"
-      assert Map.get(options, :delay_to_sigkill) == 1000
+      assert Map.get(options, :delay_to_sigkill) == 1
       assert Map.get(options, :env) == [{'KEY', 'VALUE'}, {'KEY2', 'VALUE2'}]
       assert Map.get(options, :cgroup_controllers) == ["memory", "cpu"]
       assert Map.get(options, :cgroup_base) == "base"


### PR DESCRIPTION
The Elixir documentation said milliseconds and the C documentation said
microseconds. The Elixir tests and C code used microseconds. This removes
the use of microseconds and everything is now milliseconds.

This is a backwards incompatible change!

Fixes #22.