### PR TITLE
MuonTrap.Daemon new features

### DIFF
--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -142,9 +142,9 @@ defmodule MuonTrap.Daemon do
 
   @impl true
   def handle_info(
-        {port, {:data, {_, message}}}, 
+        {port, {:data, {_, message}}},
         %State{port: port, log_output: nil, msg_callback: msg_callback} = state
-        ) do
+      ) do
     dispatch_message(msg_callback, message)
     {:noreply, state}
   end
@@ -152,7 +152,8 @@ defmodule MuonTrap.Daemon do
   @impl true
   def handle_info(
         {port, {:data, {_, message}}},
-        %State{port: port, log_output: log_level, log_prefix: prefix, msg_callback: msg_callback} = state
+        %State{port: port, log_output: log_level, log_prefix: prefix, msg_callback: msg_callback} =
+          state
       ) do
     Logger.log(log_level, [prefix, message])
     dispatch_message(msg_callback, message)

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -108,12 +108,13 @@ defmodule MuonTrap.Options do
     do: Map.put(opts, :log_prefix, prefix)
 
   defp validate_option(:daemon, {:msg_callback, nil}, opts), do: opts
+
   defp validate_option(:daemon, {:msg_callback, function}, opts) when is_function(function) do
     with function_info <- Function.info(function),
          true <- function_info[:arity] == 1 do
       Map.put(opts, :msg_callback, function)
     else
-      _arity_match_error -> 
+      _arity_match_error ->
         raise(ArgumentError, "Invalid :msg_callback, only functions with /1 arity are allowed")
     end
   end

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -22,6 +22,7 @@ defmodule MuonTrap.Options do
   * `:parallelism`
   * `:env`
   * `:name` - `MuonTrap.Daemon`-only
+  * `:msg_callback` - `MuonTrap.Daemon`-only
   * `:log_output` - `MuonTrap.Daemon`-only
   * `:log_prefix` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
@@ -105,6 +106,17 @@ defmodule MuonTrap.Options do
 
   defp validate_option(:daemon, {:log_prefix, prefix}, opts) when is_binary(prefix),
     do: Map.put(opts, :log_prefix, prefix)
+
+  defp validate_option(:daemon, {:msg_callback, nil}, opts), do: opts
+  defp validate_option(:daemon, {:msg_callback, function}, opts) when is_function(function) do
+    with function_info <- Function.info(function),
+         true <- function_info[:arity] == 1 do
+      Map.put(opts, :msg_callback, function)
+    else
+      _arity_match_error -> 
+        raise(ArgumentError, "Invalid :msg_callback, only functions with /1 arity are allowed")
+    end
+  end
 
   # MuonTrap common options
   defp validate_option(_any, {:cgroup_controllers, controllers}, opts) when is_list(controllers),

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -77,6 +77,19 @@ defmodule DaemonTest do
     assert capture_log(fun) =~ "echo says: hello"
   end
 
+  test "daemon logs unhandled messages" do
+    fun = fn ->
+      {:ok, _pid} = start_supervised(daemon_spec("echo", ["hello"], name: UnhandledMsg))
+
+      send(UnhandledMsg, "this is an unhandled msg")
+
+      wait_for_close_check()
+      Logger.flush()
+    end
+
+    assert capture_log(fun) =~ "Unhandled message: \"this is an unhandled msg\""
+  end
+
   test "daemon dispatch the message to msg_callback" do
     fun = fn ->
       {:ok, _pid} =

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -80,9 +80,7 @@ defmodule DaemonTest do
   test "daemon dispatch the message to msg_callback" do
     fun = fn ->
       {:ok, _pid} =
-        start_supervised(
-          daemon_spec("echo", ["hello"], msg_callback: &msg_test_callback/1)
-        )
+        start_supervised(daemon_spec("echo", ["hello"], msg_callback: &msg_test_callback/1))
 
       wait_for_close_check()
       Logger.flush()
@@ -190,7 +188,7 @@ defmodule DaemonTest do
     assert memory > 1000
   end
 
-  def msg_test_callback(msg) do 
+  def msg_test_callback(msg) do
     require Logger
     Logger.log(:info, ["msg_callback echo says: ", msg])
   end

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -77,6 +77,20 @@ defmodule DaemonTest do
     assert capture_log(fun) =~ "echo says: hello"
   end
 
+  test "daemon dispatch the message to msg_callback" do
+    fun = fn ->
+      {:ok, _pid} =
+        start_supervised(
+          daemon_spec("echo", ["hello"], msg_callback: &msg_test_callback/1)
+        )
+
+      wait_for_close_check()
+      Logger.flush()
+    end
+
+    assert capture_log(fun) =~ "msg_callback echo says: hello"
+  end
+
   test "can pass environment variables to the daemon" do
     fun = fn ->
       {:ok, _pid} =
@@ -174,5 +188,10 @@ defmodule DaemonTest do
     {:ok, memory_str} = Daemon.cgget(pid, "memory", "memory.limit_in_bytes")
     memory = Integer.parse(memory_str)
     assert memory > 1000
+  end
+
+  def msg_test_callback(msg) do 
+    require Logger
+    Logger.log(:info, ["msg_callback echo says: ", msg])
   end
 end

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -75,6 +75,8 @@ defmodule MuonTrap.OptionsTest do
     |> Map.get(:msg_callback)
     |> Kernel.==(&inspect/1)
     |> assert()
+
+    assert Map.get(Options.validate(:daemon, "echo", [], msg_callback: nil), :msg_callback) == nil
   end
 
   test "common commands basically work" do

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -59,6 +59,21 @@ defmodule MuonTrap.OptionsTest do
     assert_raise ArgumentError, fn ->
       Options.validate(:daemon, "echo", [], log_output: :bad_level)
     end
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:daemon, "echo", [], msg_callback: false)
+    end
+
+    raise_msg = "Invalid :msg_callback, only functions with /1 arity are allowed"
+    assert_raise ArgumentError, raise_msg, fn ->
+      Options.validate(:daemon, "echo", [], msg_callback: &Kernel.+/2)
+    end
+
+    :daemon
+    |> Options.validate("echo", [], msg_callback: &inspect/1)
+    |> Map.get(:msg_callback) 
+    |> Kernel.==(&inspect/1)
+    |> assert()
   end
 
   test "common commands basically work" do

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -65,13 +65,14 @@ defmodule MuonTrap.OptionsTest do
     end
 
     raise_msg = "Invalid :msg_callback, only functions with /1 arity are allowed"
+
     assert_raise ArgumentError, raise_msg, fn ->
       Options.validate(:daemon, "echo", [], msg_callback: &Kernel.+/2)
     end
 
     :daemon
     |> Options.validate("echo", [], msg_callback: &inspect/1)
-    |> Map.get(:msg_callback) 
+    |> Map.get(:msg_callback)
     |> Kernel.==(&inspect/1)
     |> assert()
   end


### PR DESCRIPTION
In response of #30 

I added the following option in `MuonTrap.Daemon`:
- msg_callback:  accepts anonymous functions to be executed with the daemons outputs. 
