### PR TITLE
feat: add daemon log_transform option

### DIFF
--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -39,7 +39,7 @@ defmodule MuonTrap.Daemon do
   defmodule State do
     @moduledoc false
 
-    defstruct [:command, :port, :cgroup_path, :log_output, :log_prefix]
+    defstruct [:command, :port, :cgroup_path, :log_output, :log_prefix, :log_transform]
   end
 
   def child_spec([command, args]) do
@@ -108,7 +108,8 @@ defmodule MuonTrap.Daemon do
        port: port,
        cgroup_path: Map.get(options, :cgroup_path),
        log_output: Map.get(options, :log_output),
-       log_prefix: Map.get(options, :log_prefix, command <> ": ")
+       log_prefix: Map.get(options, :log_prefix, command <> ": "),
+       log_transform: Map.get(options, :log_transform, &Function.identity/1)
      }}
   end
 
@@ -147,9 +148,9 @@ defmodule MuonTrap.Daemon do
   @impl true
   def handle_info(
         {port, {:data, {_, message}}},
-        %State{port: port, log_output: log_level, log_prefix: prefix} = state
+        %State{port: port, log_output: log_level, log_prefix: prefix, log_transform: log_transform} = state
       ) do
-    Logger.log(log_level, [prefix, message])
+    Logger.log(log_level, [prefix, log_transform.(message)])
     {:noreply, state}
   end
 

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -24,6 +24,7 @@ defmodule MuonTrap.Options do
   * `:name` - `MuonTrap.Daemon`-only
   * `:log_output` - `MuonTrap.Daemon`-only
   * `:log_prefix` - `MuonTrap.Daemon`-only
+  * `:log_transform` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
   * `:cgroup_path`
   * `:cgroup_base`
@@ -105,6 +106,9 @@ defmodule MuonTrap.Options do
 
   defp validate_option(:daemon, {:log_prefix, prefix}, opts) when is_binary(prefix),
     do: Map.put(opts, :log_prefix, prefix)
+
+  defp validate_option(:daemon, {:log_transform, log_transform}, opts) when is_function(log_transform),
+    do: Map.put(opts, :log_transform, log_transform)
 
   # MuonTrap common options
   defp validate_option(_any, {:cgroup_controllers, controllers}, opts) when is_list(controllers),


### PR DESCRIPTION
This PR adds a `log_transform` option that accepts a `string -> string` function

The purpose of this feature is to allow modifying the process output before it hits the logs. 
For instance, in our specific case, that meant stripping redundant timestamps.