### PR TITLE
Add optional function to Daemon convert exit status to stop reason

### DIFF
--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -25,6 +25,7 @@ defmodule MuonTrap.Options do
   * `:log_output` - `MuonTrap.Daemon`-only
   * `:log_prefix` - `MuonTrap.Daemon`-only
   * `:log_transform` - `MuonTrap.Daemon`-only
+  * `:exit_status_to_reason` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
   * `:cgroup_path`
   * `:cgroup_base`
@@ -110,6 +111,10 @@ defmodule MuonTrap.Options do
   defp validate_option(:daemon, {:log_transform, log_transform}, opts)
        when is_function(log_transform),
        do: Map.put(opts, :log_transform, log_transform)
+
+  defp validate_option(:daemon, {:exit_status_to_reason, exit_status_to_reason}, opts)
+       when is_function(exit_status_to_reason),
+       do: Map.put(opts, :exit_status_to_reason, exit_status_to_reason)
 
   # MuonTrap common options
   defp validate_option(_any, {:cgroup_controllers, controllers}, opts) when is_list(controllers),

--- a/test/kill_self_with_sigusr1.c
+++ b/test/kill_self_with_sigusr1.c
@@ -1,0 +1,18 @@
+#include <err.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    // This test kills itself with a SIGUSR1 to see if
+    // muontrap reports the expected exit code.
+    if (kill(getpid(), SIGUSR1) < 0)
+        err(EXIT_FAILURE, "kill");
+
+    // Give the OS up to a second to deliver the signal.
+    sleep(1);
+
+    errx(EXIT_FAILURE, "expected a signal");
+}
+


### PR DESCRIPTION
Currently `MuonTrap.Daemon` exits with either `:normal` or `:error_exit_status` whenever the monitored process exits. 

In our case, we have additional granularity when the process exists with `sigusr1` or `sigusr2` and would like to map the exit status to other stop reasons.

For now, I have the optional function configured through `:exit_status_to_reason` but the name can be changed to be more clear or less verbose. (i.e. `:exit_status_to_stop_reason` or `exit_status_transform`. 