### PR TITLE
Add logging flow controler

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,24 @@ for setting the `:id` and the `:restart` parameters:
       )
 ```
 
+## Output protections
+
+If using `MuonTrap.cmd/3` or logging enabled with `MuonTrap.Daemon.start_link/3`
+, then it is possible for the port process to flood the calling Elixir process
+with messages faster than it can handle. In those situations, the Elixir process
+mailbox will grow unbounded, filling the system memory until the BEAM eventually
+crashes with Out-Of-Memory (OOM) errors. This is most typically seen in smaller
+memory devices, like embedded systems.
+
+To counter this, a `:log_limit` option is supported to introduce flow control
+between the Elixir and port process. The port process will only log
+stderr/stdout back to the Elixir port up to the limit and wait for the Elixir
+process to report back how many bytes have been handled and are avialable for
+logging again. This flow control should provide enough push-back to prevent
+mailboxes overflowing memory.
+
+The default `:log_limit` is 10KB
+
 ## muontrap development
 
 In order to run the tests, some additional tools need to be installed.

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -29,6 +29,7 @@ defmodule MuonTrap.Options do
   * `:log_output` - `MuonTrap.Daemon`-only
   * `:log_prefix` - `MuonTrap.Daemon`-only
   * `:log_transform` - `MuonTrap.Daemon`-only
+  * `:log_limit`
   * `:exit_status_to_reason` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
   * `:cgroup_path`
@@ -115,6 +116,9 @@ defmodule MuonTrap.Options do
   defp validate_option(:daemon, {:log_transform, log_transform}, opts)
        when is_function(log_transform),
        do: Map.put(opts, :log_transform, log_transform)
+
+  defp validate_option(_any, {:log_limit, limit}, opts) when is_integer(limit),
+    do: Map.put(opts, :log_limit, limit)
 
   defp validate_option(:daemon, {:exit_status_to_reason, exit_status_to_reason}, opts)
        when is_function(exit_status_to_reason),

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -74,6 +74,7 @@ defmodule MuonTrap.OptionsTest do
       uid: 5,
       gid: "bill",
       delay_to_sigkill: 1,
+      log_limit: 1024,
       env: [{"KEY", "VALUE"}, {"KEY2", "VALUE2"}],
       cgroup_controllers: ["memory", "cpu"],
       cgroup_base: "base",
@@ -90,6 +91,7 @@ defmodule MuonTrap.OptionsTest do
       assert Map.get(options, :uid) == 5
       assert Map.get(options, :gid) == "bill"
       assert Map.get(options, :delay_to_sigkill) == 1
+      assert Map.get(options, :log_limit) == 1024
       assert Map.get(options, :env) == [{'KEY', 'VALUE'}, {'KEY2', 'VALUE2'}]
       assert Map.get(options, :cgroup_controllers) == ["memory", "cpu"]
       assert Map.get(options, :cgroup_base) == "base"

--- a/test/port_test.exs
+++ b/test/port_test.exs
@@ -12,7 +12,6 @@ defmodule MuonTrapPortTest do
     assert port_options == [
              :use_stdio,
              :exit_status,
-             :binary,
              :hide,
              {:args, ["--", "/bin/echo", "1", "2", "3"]}
            ]
@@ -157,6 +156,23 @@ defmodule MuonTrapPortTest do
     assert Keyword.get(port_options, :args) == [
              "--delay-to-sigkill",
              "123",
+             "--",
+             "/bin/echo"
+           ]
+  end
+
+  test "parses log-limit" do
+    options = %{
+      cmd: "/bin/echo",
+      args: [],
+      log_limit: 1024
+    }
+
+    port_options = MuonTrap.Port.port_options(options)
+
+    assert Keyword.get(port_options, :args) == [
+             "--log-limit",
+             "1024",
              "--",
              "/bin/echo"
            ]


### PR DESCRIPTION
There can be cases where the C process is blasting STDOUT/STDERR so fast that it floods the MuonTrap process with messages it cannot keep up with handling. Eventually this can build up to a state of overloaded memory and crash the system. This is most typically seen in smaller memory devices, like embedded systems.

This introduces a bit of flow control in the `muontrap` port to allow pushback from the Elixir process and keep the memory buildup from happening.

It does this by:

* Having C side having a maximum of 10K in flight before halting and waiting for the okay signal from Elixir
  * Writing 1Kb chunks of data to Elixir
  * Requires Elixir to send byte messages to dictate when writing can continue
* Changing the port processing to streaming lists of characters
  * Using `:line` port option could cause the underlying process to accumulate messages in the background until the line limit or newline character is found before formatting that and sending it through the `handle_info/2` callback of the GenServer
  * Since the control flow requires Elixir to mark the C process to allow writing, using `:line` would create situations where Elixir could incorrectly mark as ready while there were still lots of messages accumulating to be grouped by line