### PR TITLE
Fix tests on MacOS

### DIFF
--- a/test/muontrap_test.exs
+++ b/test/muontrap_test.exs
@@ -98,14 +98,15 @@ defmodule MuonTrapTest do
     assert {["hello\n"], 0} = MuonTrap.cmd("echo", ["hello"], opts)
   end
 
+  # Test adapted from https://github.com/elixir-lang/elixir/blob/v1.15.0/lib/elixir/test/elixir/system_test.exs#L121
   @echo "echo-elixir-test"
-  @tmp_path Path.join(__DIR__, "tmp")
+  @tag :tmp_dir
+  test "cmd/2 with absolute and relative paths", config do
+    echo = Path.join(config.tmp_dir, @echo)
+    File.mkdir_p!(Path.dirname(echo))
+    File.ln_s!(System.find_executable("echo"), echo)
 
-  test "cmd/2 with absolute and relative paths" do
-    File.mkdir_p!(@tmp_path)
-    File.cp!(System.find_executable("echo"), Path.join(@tmp_path, @echo))
-
-    File.cd!(@tmp_path, fn ->
+    File.cd!(Path.dirname(echo), fn ->
       # There is a bug in OTP where find_executable is finding
       # entries on the current directory. If this is the case,
       # we should avoid the assertion below.
@@ -116,8 +117,6 @@ defmodule MuonTrapTest do
       assert {"hello\n", 0} =
                MuonTrap.cmd(Path.join(File.cwd!(), @echo), ["hello"], [{:arg0, "echo"}])
     end)
-  after
-    File.rm_rf!(@tmp_path)
   end
 
   test "signals return an exit code of 128 + signal" do


### PR DESCRIPTION
* Fix absolute path test on MacOS
* Deduce SIGUSR1 signal number based on system
* Reorder assertions for pid exit
  * Some tests would sporadically fail because we would expect the pid to be closed too early. In a few daemon tests, that expectation was moved to after an `assert_receive` check which has a 100ms timeout which is plenty of time to get the message and ensure the pid was closed