### PR TITLE
Discard stderr when redirected it to stdout and not logging

### DIFF
--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -168,6 +168,16 @@ static int fork_exec(const char *path, char *const *argv)
 
             if (dup2(dev_null_fd, STDOUT_FILENO) < 0)
                 err(EXIT_FAILURE, "dup2 STDOUT_FILENO");
+
+            // If not capturing output at all, but the user says to capture
+            // stderr, send stderr to /dev/null as well. As odd as this sounds
+            // here, it's due to the `:stderr_to_stdout` option mapping to
+            // `capture_stderr`.
+            if (capture_stderr) {
+                if (dup2(dev_null_fd, STDERR_FILENO) < 0)
+                    err(EXIT_FAILURE, "dup2 STDERR_FILENO");
+            }
+
             close(dev_null_fd);
         }
 

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -60,14 +60,15 @@ defmodule DaemonTest do
 
   test "daemon doesn't log output by default" do
     fun = fn ->
-      {:ok, _pid} = start_supervised(daemon_spec("echo", ["hello"], stderr_to_stdout: true))
+      {:ok, _pid} =
+        start_supervised(daemon_spec(test_path("echo_stdio.test"), [], stderr_to_stdout: true))
 
       wait_for_close_check()
 
       Logger.flush()
     end
 
-    refute capture_log(fun) =~ "hello"
+    assert capture_log(fun) == ""
   end
 
   test "daemon logs output to stderr when told" do


### PR DESCRIPTION
There was a regression where when the user would specify
`stderr_to_stdout: true` and also disable logging, output from stderr
would get printed with v0.3.0. This change fixes that regression by
sending stderr to /dev/null.
