### PR TITLE
Fix C compiler error with gcc 9 and 10

### DIFF
--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -514,12 +514,14 @@ static void add_controller_setting(struct controller_info *controller, const cha
 }
 
 #if defined(__linux__)
-static void process_stdio(int from_fd) {
+static void process_stdio(int from_fd)
+{
+    ssize_t written;
     if (stdio_bytes_avail <= 0)
         return;
 
 retry:
-    ssize_t written = splice(from_fd, NULL, STDOUT_FILENO, NULL, stdio_bytes_avail, SPLICE_F_MOVE);
+    written = splice(from_fd, NULL, STDOUT_FILENO, NULL, stdio_bytes_avail, SPLICE_F_MOVE);
     if (written < 0) {
         if (errno == EINTR)
             goto retry;
@@ -529,7 +531,8 @@ retry:
     stdio_bytes_avail -= written;
 }
 #else
-static void process_stdio(int from_fd) {
+static void process_stdio(int from_fd)
+{
     if (stdio_bytes_avail <= 0)
         return;
 


### PR DESCRIPTION
This fixes the following error:

```
muontrap.c: In function ‘process_stdio’:
muontrap.c:522:5: error: a label can only be part of a statement and a declaration is not a statement
  522 |     ssize_t written = splice(from_fd, NULL, STDOUT_FILENO, NULL, stdio_bytes_avail, SPLICE_F_MOVE);
      |     ^~~~~~~
make[1]: *** [Makefile:41: /root/muontrap/_build/test/lib/muontrap/obj/muontrap.o] Error 1
make: *** [Makefile:5: all] Error 2
```

Fixes #54
