### PR TITLE
Add test to verify killing chatty processes

### DIFF
--- a/test/chatty.c
+++ b/test/chatty.c
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2018 Frank Hunleth
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+
+int main(void)
+{
+  /* Make standard output unbuffered. */
+  setvbuf(stdout, (char *)NULL, _IONBF, 0);
+
+  while (1)
+    printf("Hello, world!\n");
+
+  return 0;
+}


### PR DESCRIPTION
As the original error was timing-related, there's a possibility that
this test can produce false negatives. On my machine, the test nearly
always fails on the first iteration when the bug is present. By my
rough estimate, false negatives occured ~1-2% of the time (likely
influenced by factors like system load, which could be an issue for CI).

Closes #60.
