### PR TITLE
Add a timeout option to `MuonTrap.cmd/3`

### DIFF
--- a/lib/muontrap.ex
+++ b/lib/muontrap.ex
@@ -60,6 +60,10 @@ defmodule MuonTrap do
     * `:delay_to_sigkill` - milliseconds before sending a SIGKILL to a child process if it doesn't exit with a SIGTERM (default 500 ms)
     * `:uid` - run the command using the specified uid or username
     * `:gid` - run the command using the specified gid or group
+    * `:timeout` - milliseconds to wait for the command to complete. If the
+      command does not exit before the timeout, the return value will contain
+      the output up to that point and `:timeout` as the exit status. The child
+      process will be sent SIGTERM
 
   The following `System.cmd/3` options are also available:
 
@@ -96,9 +100,14 @@ defmodule MuonTrap do
   iex-donttest> MuonTrap.cmd("echo", ["hello"], cgroup_controllers: ["memory"], cgroup_path: "muontrap/test", cgroup_sets: [{"memory", "memory.limit_in_bytes", "8192"}])
   {"", 1}
   ```
+
+  Run a command with a timeout:
+
+  iex> MuonTrap.cmd("/bin/sh", ["-c", "echo start && sleep 10 && echo end"], timeout: 100)
+  {"start\n", :timeout}
   """
   @spec cmd(binary(), [binary()], keyword()) ::
-          {Collectable.t(), exit_status :: non_neg_integer()}
+          {Collectable.t(), exit_status :: non_neg_integer() | :timeout}
   def cmd(command, args, opts \\ []) when is_binary(command) and is_list(args) do
     options = MuonTrap.Options.validate(:cmd, command, args, opts)
 

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -38,6 +38,7 @@ defmodule MuonTrap.Options do
   * `:cgroup_sets`
   * `:uid`
   * `:gid`
+  * `:timeout` - `MuonTrap.cmd/3` only
 
   """
   @type t() :: map()
@@ -147,6 +148,9 @@ defmodule MuonTrap.Options do
 
   defp validate_option(_any, {:gid, id}, opts) when is_integer(id) or is_binary(id),
     do: Map.put(opts, :gid, id)
+
+  defp validate_option(:cmd, {:timeout, timeout}, opts) when is_integer(timeout) and timeout > 0,
+    do: Map.put(opts, :timeout, timeout)
 
   defp validate_option(_any, {key, val}, _opts),
     do: raise(ArgumentError, "invalid option #{inspect(key)} with value #{inspect(val)}")

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -39,6 +39,7 @@ defmodule MuonTrap.OptionsTest do
   test "cmd and daemon-specific options" do
     # :cmd-only
     assert Map.get(Options.validate(:cmd, "echo", [], into: ""), :into) == ""
+    assert Map.get(Options.validate(:cmd, "echo", [], timeout: 1000), :timeout) == 1000
 
     assert_raise ArgumentError, fn ->
       Options.validate(:daemon, "echo", [], into: "")
@@ -62,6 +63,10 @@ defmodule MuonTrap.OptionsTest do
 
     assert_raise ArgumentError, fn ->
       Options.validate(:daemon, "echo", [], log_output: :bad_level)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:daemon, "echo", [], timeout: 1000)
     end
   end
 


### PR DESCRIPTION
This allows callers to use `MuonTrap.cmd/3` with programs that have a
possibility of hanging forever without having to wrap the call in a
`Task`.

A child process exceeding the given timeout will be shut down in the
same way as a `MuonTrap.Daemon` (SIGTERM, followed by SIGKILL after
`:delay_to_sigkill` milliseconds). The returned value will contain the
child's output up to that point and `:timeout` in place of an exit
status.

Backward compatibility is preserved as the returned exit status will be
`:timeout` if and only if the new timeout option is present.
