### PR TITLE
Prevent non-utf8 from crashing the logger

### DIFF
--- a/test/echo_junk.c
+++ b/test/echo_junk.c
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2018 Frank Hunleth
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main()
+{
+    const char junk[] = {253, 245, 116, 105, 238, 103, 33, 99, 235, 229, 124, 121, 255, 229, 10};
+
+    fwrite(junk, sizeof(junk), 1, stdout);
+    fflush(stdout);
+
+    // Hang out long enough to satisfy the tests
+    sleep(200);
+    exit(0);
+}


### PR DESCRIPTION
In some cases, the underlying program may send non-utf8 characters which would result in the logger crashing trying to format it. The logger recovers just fine, but it could cause lots of unnecessary reporting.

This changes to validate log output before attempting to log it