### PR TITLE
Update CI Elixir/OTP versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,13 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.15.7-erlang-26.*$"
+  pattern: "^1.16.*$"
 
 tags:
   &tags [
-    1.15.7-erlang-26.1.2-alpine-3.18.4,
-    1.14.5-erlang-25.3.2-alpine-3.18.0,
+    1.16.1-erlang-26.2.2-alpine-3.19.1,
+    1.15.7-erlang-26.2.2-alpine-3.19.1,
+    1.14.5-erlang-25.3.2.9-alpine-3.19.1,
     1.13.4-erlang-24.3.4-alpine-3.15.3,
     1.12.3-erlang-24.3.4-alpine-3.15.3,
     1.11.4-erlang-23.3.4.13-alpine-3.15.3,


### PR DESCRIPTION
Adds Elixir 1.16.1 / OTP 26.2.2 and bumps the OTP/Alpine versions of Elixir 1.15 and 1.14