### PR TITLE
Add Logger metadata in `MuonTrap.Daemon`

### DIFF
--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -31,6 +31,9 @@ defmodule MuonTrap.Daemon do
   * `:log_transform` - Pass a function that takes a string and returns a string
     to format output from the command. Defaults to `String.replace_invalid/1`
     on Elixir 1.16+ to avoid crashing the logger on non-UTF8 output.
+  * `:logger_metadata` - A keyword list to merge into the process's logger metadata.
+    The `:muontrap_cmd` and `:muontrap_args` keys are automatically added and
+    cannot be overridden.
   * `:stderr_to_stdout` - When set to `true`, redirect stderr to stdout.
     Defaults to `false`.
   * `:exit_status_to_reason` - Optional function to convert the exit status (a
@@ -136,6 +139,11 @@ defmodule MuonTrap.Daemon do
     port_options = MuonTrap.Port.port_options(options) ++ [:stream]
 
     port = Port.open({:spawn_executable, to_charlist(MuonTrap.muontrap_path())}, port_options)
+
+    options
+    |> Map.get(:logger_metadata, [])
+    |> Keyword.merge(muontrap_cmd: command, muontrap_args: Enum.join(args, " "))
+    |> Logger.metadata()
 
     {:ok,
      %__MODULE__{

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -29,6 +29,7 @@ defmodule MuonTrap.Options do
   * `:log_output` - `MuonTrap.Daemon`-only
   * `:log_prefix` - `MuonTrap.Daemon`-only
   * `:log_transform` - `MuonTrap.Daemon`-only
+  * `:logger_metadata` - `MuonTrap.Daemon`-only
   * `:stdio_window`
   * `:exit_status_to_reason` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
@@ -120,6 +121,9 @@ defmodule MuonTrap.Options do
   defp validate_option(:daemon, {:log_transform, log_transform}, opts)
        when is_function(log_transform),
        do: Map.put(opts, :log_transform, log_transform)
+
+  defp validate_option(:daemon, {:logger_metadata, metadata}, opts) when is_list(metadata),
+    do: Map.put(opts, :logger_metadata, metadata)
 
   defp validate_option(_any, {:stdio_window, count}, opts) when is_integer(count),
     do: Map.put(opts, :stdio_window, count)

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -68,6 +68,15 @@ defmodule MuonTrap.OptionsTest do
     assert_raise ArgumentError, fn ->
       Options.validate(:daemon, "echo", [], timeout: 1000)
     end
+
+    assert Map.get(
+             Options.validate(:daemon, "echo", [], logger_metadata: [foo: :bar]),
+             :logger_metadata
+           ) == [foo: :bar]
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:cmd, "echo", [], logger_metadata: [foo: :bar])
+    end
   end
 
   test "common commands basically work" do


### PR DESCRIPTION
This adds the `:muontrap_cmd` and `:muontrap_args` keys to Logger
metadata in `MuonTrap.Daemon` processes. Consumers can add additional
custom metadata to the process via the `:logger_metadata` option.

This allows for easier identification of the source of a log message
when multiple `MuonTrap.Daemon` processes are running, particularly if
they are supervising the same OS process.