### PR TITLE
Fix MuonTrap.Daemon’s @moduledoc

### DIFF
--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -10,7 +10,7 @@ defmodule MuonTrap.Daemon do
 
   ```elixir
   children = [
-    {MuonTrap.Daemon, ["my_server", ["--options", "foo"]], [cd: "/some_directory"]]}
+    {MuonTrap.Daemon, ["my_server", ["--options", "foo"], [cd: "/some_directory"]]}
   ]
 
   opts = [strategy: :one_for_one, name: MyApplication.Supervisor]


### PR DESCRIPTION
Stumbled upon this typo when I was trying to spawn a named child that I can later kill from anywhere[^1] in my application to get the underlying binary to restart/reload its configuration.

[^1]: As I was typing this, I realized that sending a HUP signal would probably be cleaner…