### PR TITLE
Allow custom logger function in `MuonTrap.Daemon`

### DIFF
--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -141,6 +141,7 @@ defmodule MuonTrap.Daemon do
 
     port = Port.open({:spawn_executable, to_charlist(MuonTrap.muontrap_path())}, port_options)
 
+    # Logger.metadata/0 has a side effect to set the metadata for the current process
     options
     |> Map.get(:logger_metadata, [])
     |> Keyword.merge(muontrap_cmd: command, muontrap_args: Enum.join(args, " "))

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -26,11 +26,11 @@ defmodule MuonTrap.Options do
   * `:parallelism`
   * `:env`
   * `:name` - `MuonTrap.Daemon`-only
-  * `:custom_logger` - `MuonTrap.Daemon`-only
-  * `:log_output` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
-  * `:log_prefix` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
-  * `:log_transform` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
-  * `:logger_metadata` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
+  * `:logger_fun` - `MuonTrap.Daemon`-only
+  * `:log_output` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
+  * `:log_prefix` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
+  * `:log_transform` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
+  * `:logger_metadata` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
   * `:stdio_window`
   * `:exit_status_to_reason` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
@@ -126,22 +126,22 @@ defmodule MuonTrap.Options do
   defp validate_option(:daemon, {:logger_metadata, metadata}, opts) when is_list(metadata),
     do: Map.put(opts, :logger_metadata, metadata)
 
-  defp validate_option(:daemon, {:custom_logger, logger}, opts) when is_function(logger, 1),
-    do: Map.put(opts, :custom_logger, logger)
+  defp validate_option(:daemon, {:logger_fun, logger}, opts) when is_function(logger, 1),
+    do: Map.put(opts, :logger_fun, logger)
 
-  defp validate_option(:daemon, {:custom_logger, {m, f, a}}, opts)
+  defp validate_option(:daemon, {:logger_fun, {m, f, a}}, opts)
        when is_atom(m) and is_atom(f) and is_list(a),
-       do: Map.put(opts, :custom_logger, {m, f, a})
+       do: Map.put(opts, :logger_fun, {m, f, a})
 
-  defp validate_option(:daemon, {:custom_logger, {m, f}}, opts)
+  defp validate_option(:daemon, {:logger_fun, {m, f}}, opts)
        when is_atom(m) and is_atom(f),
-       do: Map.put(opts, :custom_logger, {m, f, []})
+       do: Map.put(opts, :logger_fun, {m, f, []})
 
-  defp validate_option(:daemon, {:custom_logger, v}, _opts),
+  defp validate_option(:daemon, {:logger_fun, v}, _opts),
     do:
       raise(
         ArgumentError,
-        "invalid option :custom_logger with value #{inspect(v)}, expected a 1-arity function or an mfa tuple"
+        "invalid option :logger_fun with value #{inspect(v)}, expected a 1-arity function or an mfa tuple"
       )
 
   defp validate_option(_any, {:stdio_window, count}, opts) when is_integer(count),

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -30,7 +30,7 @@ defmodule MuonTrap.Options do
   * `:log_output` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
   * `:log_prefix` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
   * `:log_transform` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
-  * `:logger_metadata` - `MuonTrap.Daemon`-only, ignored if logger_fun is set
+  * `:logger_metadata` - `MuonTrap.Daemon`-only, ignored if logger_fun is set and doesn't call the Elixir Logger
   * `:stdio_window`
   * `:exit_status_to_reason` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -26,10 +26,11 @@ defmodule MuonTrap.Options do
   * `:parallelism`
   * `:env`
   * `:name` - `MuonTrap.Daemon`-only
-  * `:log_output` - `MuonTrap.Daemon`-only
-  * `:log_prefix` - `MuonTrap.Daemon`-only
-  * `:log_transform` - `MuonTrap.Daemon`-only
-  * `:logger_metadata` - `MuonTrap.Daemon`-only
+  * `:custom_logger` - `MuonTrap.Daemon`-only
+  * `:log_output` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
+  * `:log_prefix` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
+  * `:log_transform` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
+  * `:logger_metadata` - `MuonTrap.Daemon`-only, ignored if custom_logger is set
   * `:stdio_window`
   * `:exit_status_to_reason` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
@@ -124,6 +125,24 @@ defmodule MuonTrap.Options do
 
   defp validate_option(:daemon, {:logger_metadata, metadata}, opts) when is_list(metadata),
     do: Map.put(opts, :logger_metadata, metadata)
+
+  defp validate_option(:daemon, {:custom_logger, logger}, opts) when is_function(logger, 1),
+    do: Map.put(opts, :custom_logger, logger)
+
+  defp validate_option(:daemon, {:custom_logger, {m, f, a}}, opts)
+       when is_atom(m) and is_atom(f) and is_list(a),
+       do: Map.put(opts, :custom_logger, {m, f, a})
+
+  defp validate_option(:daemon, {:custom_logger, {m, f}}, opts)
+       when is_atom(m) and is_atom(f),
+       do: Map.put(opts, :custom_logger, {m, f, []})
+
+  defp validate_option(:daemon, {:custom_logger, v}, _opts),
+    do:
+      raise(
+        ArgumentError,
+        "invalid option :custom_logger with value #{inspect(v)}, expected a 1-arity function or an mfa tuple"
+      )
 
   defp validate_option(_any, {:stdio_window, count}, opts) when is_integer(count),
     do: Map.put(opts, :stdio_window, count)

--- a/lib/muontrap/port.ex
+++ b/lib/muontrap/port.ex
@@ -75,7 +75,7 @@ defmodule MuonTrap.Port do
   defp muontrap_arg({:stdio_window, count}), do: ["--stdio-window", to_string(count)]
   defp muontrap_arg({:stderr_to_stdout, true}), do: ["--capture-stderr"]
 
-  defp muontrap_arg({log_opt, _}) when log_opt in [:log_output, :custom_logger],
+  defp muontrap_arg({log_opt, _}) when log_opt in [:log_output, :logger_fun],
     do: ["--capture-output"]
 
   defp muontrap_arg({:cgroup_controllers, controllers}) do

--- a/lib/muontrap/port.ex
+++ b/lib/muontrap/port.ex
@@ -74,7 +74,9 @@ defmodule MuonTrap.Port do
   defp muontrap_arg({:arg0, arg0}), do: ["--arg0", arg0]
   defp muontrap_arg({:stdio_window, count}), do: ["--stdio-window", to_string(count)]
   defp muontrap_arg({:stderr_to_stdout, true}), do: ["--capture-stderr"]
-  defp muontrap_arg({:log_output, _}), do: ["--capture-output"]
+
+  defp muontrap_arg({log_opt, _}) when log_opt in [:log_output, :custom_logger],
+    do: ["--capture-output"]
 
   defp muontrap_arg({:cgroup_controllers, controllers}) do
     Enum.flat_map(controllers, fn controller -> ["--controller", controller] end)

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -211,7 +211,7 @@ defmodule DaemonTest do
         start_supervised(
           daemon_spec(test_path("echo_stdio.test"), [],
             log_output: :error,
-            custom_logger: logger,
+            logger_fun: logger,
             stderr_to_stdout: false
           )
         )
@@ -235,7 +235,7 @@ defmodule DaemonTest do
         start_supervised(
           daemon_spec(test_path("echo_stdio.test"), [],
             log_output: :error,
-            custom_logger: {__MODULE__, :custom_logger_fun},
+            logger_fun: {__MODULE__, :logger_fun_fun},
             stderr_to_stdout: false
           )
         )
@@ -248,7 +248,7 @@ defmodule DaemonTest do
     log_output = capture_log(fun)
 
     assert log_output =~ "stdout here"
-    refute log_output =~ "custom_logger"
+    refute log_output =~ "logger_fun"
 
     stop_supervised(:test_daemon)
 
@@ -257,7 +257,7 @@ defmodule DaemonTest do
         start_supervised(
           daemon_spec(test_path("echo_stdio.test"), [],
             log_output: :error,
-            custom_logger: {__MODULE__, :custom_logger_fun, ["custom_logger: "]},
+            logger_fun: {__MODULE__, :logger_fun_fun, ["logger_fun: "]},
             stderr_to_stdout: false
           )
         )
@@ -269,11 +269,11 @@ defmodule DaemonTest do
 
     log_output = capture_log(fun)
 
-    assert log_output =~ "custom_logger: stdout here"
+    assert log_output =~ "logger_fun: stdout here"
   end
 
-  @spec custom_logger_fun(binary(), binary()) :: :ok
-  def custom_logger_fun(line, prefix \\ "") do
+  @spec logger_fun_fun(binary(), binary()) :: :ok
+  def logger_fun_fun(line, prefix \\ "") do
     require Logger
     Logger.info([prefix, line])
   end

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -77,6 +77,33 @@ defmodule MuonTrap.OptionsTest do
     assert_raise ArgumentError, fn ->
       Options.validate(:cmd, "echo", [], logger_metadata: [foo: :bar])
     end
+
+    assert is_function(
+             Map.get(
+               Options.validate(:daemon, "echo", [], custom_logger: &Function.identity/1),
+               :custom_logger
+             )
+           )
+
+    assert {Function, :identity, []} =
+             Map.get(
+               Options.validate(:daemon, "echo", [], custom_logger: {Function, :identity, []}),
+               :custom_logger
+             )
+
+    assert {Function, :identity, []} =
+             Map.get(
+               Options.validate(:daemon, "echo", [], custom_logger: {Function, :identity}),
+               :custom_logger
+             )
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:daemon, "echo", [], custom_logger: &DateTime.add/2)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:cmd, "echo", [], custom_logger: &Function.identity/1)
+    end
   end
 
   test "common commands basically work" do

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -80,29 +80,29 @@ defmodule MuonTrap.OptionsTest do
 
     assert is_function(
              Map.get(
-               Options.validate(:daemon, "echo", [], custom_logger: &Function.identity/1),
-               :custom_logger
+               Options.validate(:daemon, "echo", [], logger_fun: &Function.identity/1),
+               :logger_fun
              )
            )
 
     assert {Function, :identity, []} =
              Map.get(
-               Options.validate(:daemon, "echo", [], custom_logger: {Function, :identity, []}),
-               :custom_logger
+               Options.validate(:daemon, "echo", [], logger_fun: {Function, :identity, []}),
+               :logger_fun
              )
 
     assert {Function, :identity, []} =
              Map.get(
-               Options.validate(:daemon, "echo", [], custom_logger: {Function, :identity}),
-               :custom_logger
+               Options.validate(:daemon, "echo", [], logger_fun: {Function, :identity}),
+               :logger_fun
              )
 
     assert_raise ArgumentError, fn ->
-      Options.validate(:daemon, "echo", [], custom_logger: &DateTime.add/2)
+      Options.validate(:daemon, "echo", [], logger_fun: &DateTime.add/2)
     end
 
     assert_raise ArgumentError, fn ->
-      Options.validate(:cmd, "echo", [], custom_logger: &Function.identity/1)
+      Options.validate(:cmd, "echo", [], logger_fun: &Function.identity/1)
     end
   end
 


### PR DESCRIPTION
This enables finer-grained control over the use of the Elixir logger as
well as the option to use something other than the Elixir logger.

In an application where MuonTrap is used to supervise multiple programs,
it is now possible to differentiate between programs based on the
application and module in the log metadata. It is also now possible to
use features like compile-time log purging of MuonTrap logs on a
case-by-case basis.
