### PR TITLE
Don't kill process when reading from stdin results in EAGAIN, EWOULDBLOCK or EINTR

### DIFF
--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -613,7 +613,12 @@ static int child_wait_loop(pid_t child_pid, int *still_running)
             uint8_t acknowledgments[32];
             ssize_t amt = read(STDIN_FILENO, acknowledgments, sizeof(acknowledgments));
             if (amt < 0) {
-                INFO("read STDIN_FILENO");
+                INFO("read STDIN_FILENO error: %s", strerror(errno));
+
+                if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+                    continue;
+                }
+
                 return EXIT_FAILURE;
             }
 


### PR DESCRIPTION
First off, just wanted to say thank you for making MuonTrap :pray: it's been very useful for managing Phoenix watchers and has saved me a ton of headache on handling zombie processes myself.

Some background on this PR: I'm using MuonTrap to run a long-running node.js process. While investigating why MuonTrap was killing my process at random, I figured out that it's because `read` was returning `-1` and setting `errno` to `EAGAIN`.

From the (Linux) `read` man page:
> **EAGAIN** The file descriptor fd refers to a file other than a socket and has been marked nonblocking (O_NONBLOCK),  and the read would block.  See open(2) for further details on the O_NONBLOCK flag.

Since this error isn't critical, I don't think we should be returning with `EXIT_FAILURE`. Instead, I've handled it with `continue`. By handling `EAGAIN` in this way MuonTrap no longer kills my node.js process and in my testing I have not encountered any adverse effects.

In my PR you'll notice that I'm also handling `EWOULDBLOCK` - that's because the same man page also states:
> **EAGAIN** or **EWOULDBLOCK** The  file  descriptor  fd refers to a socket and has been marked nonblocking (O_NONBLOCK), and the read would block.
> POSIX.1-2001 allows either error to be returned for this case, and does not require these constants to have the same value, so a portable application should check for both possibilities.

I've also handled `EINTR` as, like with `EAGAIN`, I don't think that encountering this error should make MuonTrap kill the process it's managing.