### PR TITLE
Add `capture_stderr_only` option to only get data from `stderr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+* New feature
+  * Add `:capture_stderr_only` option to capture only stderr while ignoring stdout.
+    This is useful when you want to capture error messages but not regular output.
+    Works with both `MuonTrap.cmd/3` and `MuonTrap.Daemon`.
+
 ## v1.6.1
 
 * Bug fixes

--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,7 @@ Muontrap is open-source software licensed under the Apache License, Version
 
 Copyright holders include Frank Hunleth, Matt Ludwigs, Jason Axelson, Timmo
 Verlaan, Aldebaran Alonso, Gustavo Brunoro, Ben Youngblood, Eric Rauer, Jon
-Carstens, Milan Vit and Médi-Rémi Hashim.
+Carstens, Milan Vit, Fernando Mumbach and Médi-Rémi Hashim.
 
 Authoritative REUSE-compliant copyright and license metadata available at
 https://hex.pm/packages/muontrap.

--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -608,17 +608,17 @@ static int child_wait_loop(pid_t child_pid, int *still_running)
     for (;;) {
         poll_num = 2;
         // Also poll stdout and optionally stderr when capturing output and accepting stdio data
-        if (capture_output && stdio_bytes_avail > 0) {
-            poll_num++;
-
-            if (capture_stderr)
-                poll_num++;
-        } else if (capture_stderr_only && stdio_bytes_avail > 0) {
+        if (capture_stderr_only && stdio_bytes_avail > 0) {
             // Only polling stderr in stderr-only mode
             // fds[2] will be stderr_pipe since we're not using stdout_pipe
             fds[2].fd = stderr_pipe[0];
             fds[2].events = POLLIN;
             poll_num++;
+        } else if (capture_output && stdio_bytes_avail > 0) {
+            poll_num++;
+
+            if (capture_stderr)
+                poll_num++;
         }
 
         if (poll(fds, poll_num, -1) < 0) {

--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2018 Frank Hunleth
 // SPDX-FileCopyrightText: 2023 Jon Carstens
+// SPDX-FileCopyrightText: 2025 Fernando Mumbach
 // SPDX-FileCopyrightText: 2025 Médi-Rémi Hashim
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/lib/muontrap.ex
+++ b/lib/muontrap.ex
@@ -73,6 +73,7 @@ defmodule MuonTrap do
     * `:env` - an enumerable of tuples containing environment key-value as binary
     * `:arg0` - sets the command arg0
     * `:stderr_to_stdout` - redirects stderr to stdout when `true`
+    * `:capture_stderr_only` - when `true`, captures only stderr and ignores stdout (useful for capturing errors while ignoring normal output)
     * `:parallelism` - when `true`, the VM will schedule port tasks to improve
       parallelism in the system. If set to `false`, the VM will try to perform
       commands immediately, improving latency at the expense of parallelism.

--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2023 Jon Carstens
 # SPDX-FileCopyrightText: 2024 Ben Youngblood
 # SPDX-FileCopyrightText: 2024 Milan Vit
+# SPDX-FileCopyrightText: 2025 Fernando Mumbach
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -175,11 +175,16 @@ defmodule MuonTrap.Daemon do
 
   defp logger_fun(options, command) do
     log_output = Map.get(options, :log_output)
-    log_prefix = Map.get(options, :log_prefix, command <> ": ")
-    log_transform = Map.get(options, :log_transform, &default_transform/1)
 
-    fn line ->
-      Logger.log(log_output, [log_prefix, log_transform.(line)])
+    if log_output == nil do
+      fn _line -> :ok end
+    else
+      log_prefix = Map.get(options, :log_prefix, command <> ": ")
+      log_transform = Map.get(options, :log_transform, &default_transform/1)
+
+      fn line ->
+        Logger.log(log_output, [log_prefix, log_transform.(line)])
+      end
     end
   end
 

--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -46,6 +46,9 @@ defmodule MuonTrap.Daemon do
     cannot be overridden.
   * `:stderr_to_stdout` - When set to `true`, redirect stderr to stdout.
     Defaults to `false`.
+  * `:capture_stderr_only` - When set to `true`, capture only stderr and ignore stdout.
+    This is useful when you want to capture error messages but not regular output.
+    Defaults to `false`.
   * `:exit_status_to_reason` - Optional function to convert the exit status (a
     number) to stop reason for the Daemon GenServer. Use if error exit codes
     carry information or aren't errors.

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -26,6 +26,7 @@ defmodule MuonTrap.Options do
   * `:cd`
   * `:arg0`
   * `:stderr_to_stdout`
+  * `:capture_stderr_only`
   * `:parallelism`
   * `:env`
   * `:name` - `MuonTrap.Daemon`-only
@@ -105,6 +106,9 @@ defmodule MuonTrap.Options do
 
   defp validate_option(_any, {:stderr_to_stdout, bool}, opts) when is_boolean(bool),
     do: Map.put(opts, :stderr_to_stdout, bool)
+
+  defp validate_option(_any, {:capture_stderr_only, bool}, opts) when is_boolean(bool),
+    do: Map.put(opts, :capture_stderr_only, bool)
 
   defp validate_option(_any, {:parallelism, bool}, opts) when is_boolean(bool),
     do: Map.put(opts, :parallelism, bool)

--- a/lib/muontrap/port.ex
+++ b/lib/muontrap/port.ex
@@ -76,6 +76,7 @@ defmodule MuonTrap.Port do
   defp muontrap_arg({:arg0, arg0}), do: ["--arg0", arg0]
   defp muontrap_arg({:stdio_window, count}), do: ["--stdio-window", to_string(count)]
   defp muontrap_arg({:stderr_to_stdout, true}), do: ["--capture-stderr"]
+  defp muontrap_arg({:capture_stderr_only, true}), do: ["--capture-stderr-only"]
 
   defp muontrap_arg({log_opt, _}) when log_opt in [:log_output, :logger_fun],
     do: ["--capture-output"]

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -147,6 +147,9 @@ defmodule DaemonTest do
   end
 
   test "daemon does not log output to stderr when not told" do
+    # Need to disable ANSI since new line in log message is important
+    Application.put_env(:elixir, :ansi_enabled, false)
+
     fun = fn ->
       {:ok, pid} =
         start_supervised(
@@ -161,7 +164,11 @@ defmodule DaemonTest do
       Logger.flush()
     end
 
-    assert capture_log(fun) =~ "echo_stdio.test: stdout here\n"
+    result = capture_log(fun)
+    assert result =~ "echo_stdio.test: stdout here\n"
+    refute result =~ ".."
+
+    Application.delete_env(:elixir, :ansi_enabled)
   end
 
   test "daemon logs to a custom prefix" do

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -553,4 +553,61 @@ defmodule DaemonTest do
       assert output =~ "** MuonTrap filtered 14 non-UTF8 bytes **"
     end
   end
+
+  test "daemon captures only stderr when capture_stderr_only is set" do
+    fun = fn ->
+      {:ok, pid} =
+        start_supervised(
+          daemon_spec(test_path("echo_both.test"), [],
+            log_output: :error,
+            capture_stderr_only: true
+          )
+        )
+
+      wait_for_output(pid, 15, 500)
+      Logger.flush()
+    end
+
+    log = capture_log(fun)
+    assert log =~ "stderr message"
+    refute log =~ "stdout message"
+  end
+
+  test "daemon captures both stdout and stderr when both options are used" do
+    fun = fn ->
+      {:ok, pid} =
+        start_supervised(
+          daemon_spec(test_path("echo_both.test"), [],
+            log_output: :error,
+            stderr_to_stdout: true
+          )
+        )
+
+      wait_for_output(pid, 30, 500)
+      Logger.flush()
+    end
+
+    log = capture_log(fun)
+    assert log =~ "stderr message"
+    assert log =~ "stdout message"
+  end
+
+  test "daemon captures only stdout when stderr_to_stdout is false" do
+    fun = fn ->
+      {:ok, pid} =
+        start_supervised(
+          daemon_spec(test_path("echo_both.test"), [],
+            log_output: :error,
+            stderr_to_stdout: false
+          )
+        )
+
+      wait_for_output(pid, 15, 500)
+      Logger.flush()
+    end
+
+    log = capture_log(fun)
+    refute log =~ "stderr message"
+    assert log =~ "stdout message"
+  end
 end

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2023 Ben Youngblood
 # SPDX-FileCopyrightText: 2023 Eric Rauer
 # SPDX-FileCopyrightText: 2023 Jon Carstens
+# SPDX-FileCopyrightText: 2025 Fernando Mumbach
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/echo_both.c
+++ b/test/echo_both.c
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main()
+{
+    fprintf(stdout, "stdout message\n");
+    fflush(stdout);
+    fprintf(stderr, "stderr message\n");
+    fflush(stderr);
+    
+    // Hang out long enough to satisfy the tests
+    sleep(120);
+    exit(0);
+}

--- a/test/echo_both.c
+++ b/test/echo_both.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024
+// SPDX-FileCopyrightText: 2024 Frank Hunleth
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +12,7 @@ int main()
     fflush(stdout);
     fprintf(stderr, "stderr message\n");
     fflush(stderr);
-    
+
     // Hang out long enough to satisfy the tests
     sleep(120);
     exit(0);

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -113,6 +113,7 @@ defmodule MuonTrap.OptionsTest do
       cd: "path",
       arg0: "arg0",
       stderr_to_stdout: true,
+      capture_stderr_only: true,
       parallelism: true,
       uid: 5,
       gid: "bill",
@@ -130,6 +131,7 @@ defmodule MuonTrap.OptionsTest do
       assert Map.get(options, :cd) == "path"
       assert Map.get(options, :arg0) == "arg0"
       assert Map.get(options, :stderr_to_stdout) == true
+      assert Map.get(options, :capture_stderr_only) == true
       assert Map.get(options, :parallelism) == true
       assert Map.get(options, :uid) == 5
       assert Map.get(options, :gid) == "bill"


### PR DESCRIPTION
Based on the [work done by copilot](https://github.com/fhunleth/muontrap/pull/82).

Modified to first evaluate `capture_stderr_only`, since it modifies how `capture_output` would operate.