### PR TITLE
Add :wait_for block daemon from starting before ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ Treat the `MuonTrap.Daemon` process just like any other Elixir process. If you
 put it in a supervision tree, call `Supervisor.terminate_child/2`. If you have
 it's pid, call `Process.exit/2`.
 
+### How do I delay a daemon until a dependency is ready?
+
+Pass a 0-arity function via the `:wait_for` option. It runs in a linked `Task`
+before the OS process is launched, so it can block (e.g., poll a TCP port or
+wait on a file) without holding up the supervisor. The Daemon launches the
+command once the function returns; if it raises, the link tears the Daemon
+down and the supervisor's restart policy applies.
+
+```elixir
+{MuonTrap.Daemon,
+ ["my_server", [],
+  [wait_for: fn -> wait_for_tcp_port("db", 5432) end]]}
+```
+
 ## Background
 
 The Erlang VM's port interface lets Elixir applications run external programs.

--- a/lib/muontrap/daemon.ex
+++ b/lib/muontrap/daemon.ex
@@ -53,6 +53,9 @@ defmodule MuonTrap.Daemon do
   * `:exit_status_to_reason` - Optional function to convert the exit status (a
     number) to stop reason for the Daemon GenServer. Use if error exit codes
     carry information or aren't errors.
+  * `:wait_for` - A 0-arity function that runs before the OS process is
+    launched. Use to wait for a required resource to be available. The return
+    value is ignored. Raise to abort the launch.
 
   If you want to run multiple `MuonTrap.Daemon`s under one supervisor, they'll
   all need unique IDs. Use `Supervisor.child_spec/2` like this:
@@ -71,10 +74,12 @@ defmodule MuonTrap.Daemon do
     :buffer,
     :command,
     :port,
+    :port_options,
     :cgroup_path,
     :logger_fun,
     :exit_status_to_reason,
-    :output_byte_count
+    :output_byte_count,
+    :wait_task
   ]
 
   @max_data_to_buffer 256
@@ -150,25 +155,36 @@ defmodule MuonTrap.Daemon do
     options = MuonTrap.Options.validate(:daemon, command, args, opts)
     port_options = MuonTrap.Port.port_options(options) ++ [:stream]
 
-    port = Port.open({:spawn_executable, to_charlist(MuonTrap.muontrap_path())}, port_options)
-
     # Logger.metadata/0 has a side effect to set the metadata for the current process
     options
     |> Map.get(:logger_metadata, [])
     |> Keyword.merge(muontrap_cmd: command, muontrap_args: Enum.join(args, " "))
     |> Logger.metadata()
 
-    {:ok,
-     %__MODULE__{
-       buffer: "",
-       command: command,
-       port: port,
-       cgroup_path: Map.get(options, :cgroup_path),
-       logger_fun: logger_fun(options, command),
-       exit_status_to_reason:
-         Map.get(options, :exit_status_to_reason, fn _ -> :error_exit_status end),
-       output_byte_count: 0
-     }}
+    state = %__MODULE__{
+      buffer: "",
+      command: command,
+      port: nil,
+      port_options: port_options,
+      cgroup_path: Map.get(options, :cgroup_path),
+      logger_fun: logger_fun(options, command),
+      exit_status_to_reason:
+        Map.get(options, :exit_status_to_reason, fn _ -> :error_exit_status end),
+      output_byte_count: 0,
+      wait_task: nil
+    }
+
+    case Map.get(options, :wait_for) do
+      nil -> {:ok, start_port(state)}
+      fun -> {:ok, %{state | wait_task: Task.async(fun)}}
+    end
+  end
+
+  defp start_port(state) do
+    port =
+      Port.open({:spawn_executable, to_charlist(MuonTrap.muontrap_path())}, state.port_options)
+
+    %{state | port: port}
   end
 
   defp logger_fun(%{logger_fun: fun}, _command) when is_function(fun, 1), do: fun
@@ -220,6 +236,10 @@ defmodule MuonTrap.Daemon do
     {:reply, result, state}
   end
 
+  def handle_call(:os_pid, _from, %__MODULE__{port: nil} = state) do
+    {:reply, :error, state}
+  end
+
   def handle_call(:os_pid, _from, state) do
     os_pid =
       case Port.info(state.port, :os_pid) do
@@ -236,6 +256,11 @@ defmodule MuonTrap.Daemon do
   end
 
   @impl GenServer
+  def handle_info({ref, _result}, %__MODULE__{wait_task: %Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, start_port(%{state | wait_task: nil})}
+  end
+
   def handle_info({port, {:data, message}}, %__MODULE__{port: port} = state) do
     bytes_received = byte_size(message)
     state = split_and_log(message, state)

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -37,6 +37,7 @@ defmodule MuonTrap.Options do
   * `:logger_metadata` - `MuonTrap.Daemon`-only, ignored if logger_fun is set and doesn't call the Elixir Logger
   * `:stdio_window`
   * `:exit_status_to_reason` - `MuonTrap.Daemon`-only
+  * `:wait_for` - `MuonTrap.Daemon`-only
   * `:cgroup_controllers`
   * `:cgroup_path`
   * `:cgroup_base`
@@ -157,6 +158,16 @@ defmodule MuonTrap.Options do
   defp validate_option(:daemon, {:exit_status_to_reason, exit_status_to_reason}, opts)
        when is_function(exit_status_to_reason),
        do: Map.put(opts, :exit_status_to_reason, exit_status_to_reason)
+
+  defp validate_option(:daemon, {:wait_for, fun}, opts) when is_function(fun, 0),
+    do: Map.put(opts, :wait_for, fun)
+
+  defp validate_option(:daemon, {:wait_for, v}, _opts),
+    do:
+      raise(
+        ArgumentError,
+        "invalid option :wait_for with value #{inspect(v)}, expected a 0-arity function"
+      )
 
   # MuonTrap common options
   defp validate_option(_any, {:cgroup_controllers, controllers}, opts) when is_list(controllers),

--- a/test/daemon_test.exs
+++ b/test/daemon_test.exs
@@ -639,4 +639,70 @@ defmodule DaemonTest do
     refute log =~ "stderr message"
     assert log =~ "stdout message"
   end
+
+  test "wait_for defers launching the OS process until it returns" do
+    parent = self()
+
+    wait_fun = fn ->
+      send(parent, {:wait_started, self()})
+
+      receive do
+        :proceed -> :ok
+      end
+    end
+
+    {:ok, pid} =
+      start_supervised(daemon_spec(test_path("do_nothing.test"), [], wait_for: wait_fun))
+
+    assert_receive {:wait_started, task_pid}, 1000
+    assert :error == Daemon.os_pid(pid)
+    assert Process.alive?(task_pid)
+
+    send(task_pid, :proceed)
+
+    os_pid = wait_for_os_pid(pid)
+    assert_os_pid_running(os_pid)
+  end
+
+  test "wait_for raising crashes the daemon via the link" do
+    Process.flag(:trap_exit, true)
+
+    {:ok, pid} =
+      Daemon.start_link(test_path("do_nothing.test"), [], wait_for: fn -> raise "boom" end)
+
+    assert_receive {:EXIT, ^pid, {%RuntimeError{message: "boom"}, _}}, 1000
+  end
+
+  test "stopping the daemon while wait_for is still running terminates the wait task" do
+    parent = self()
+
+    wait_fun = fn ->
+      send(parent, {:wait_started, self()})
+      Process.sleep(:infinity)
+    end
+
+    {:ok, _pid} =
+      start_supervised(daemon_spec(test_path("do_nothing.test"), [], wait_for: wait_fun))
+
+    assert_receive {:wait_started, task_pid}, 1000
+    ref = Process.monitor(task_pid)
+
+    :ok = stop_supervised(:test_daemon)
+
+    assert_receive {:DOWN, ^ref, :process, ^task_pid, _}, 1000
+  end
+
+  defp wait_for_os_pid(pid, attempts \\ 50)
+  defp wait_for_os_pid(_pid, 0), do: flunk("OS process never started")
+
+  defp wait_for_os_pid(pid, attempts) do
+    case Daemon.os_pid(pid) do
+      :error ->
+        Process.sleep(20)
+        wait_for_os_pid(pid, attempts - 1)
+
+      os_pid when is_integer(os_pid) ->
+        os_pid
+    end
+  end
 end

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -106,6 +106,26 @@ defmodule MuonTrap.OptionsTest do
     assert_raise ArgumentError, fn ->
       Options.validate(:cmd, "echo", [], logger_fun: &Function.identity/1)
     end
+
+    # :wait_for is :daemon-only and must be a 0-arity function
+    wait_fun = fn -> :ok end
+
+    assert is_function(
+             Map.get(Options.validate(:daemon, "echo", [], wait_for: wait_fun), :wait_for),
+             0
+           )
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:cmd, "echo", [], wait_for: wait_fun)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:daemon, "echo", [], wait_for: :not_a_fun)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Options.validate(:daemon, "echo", [], wait_for: &Function.identity/1)
+    end
   end
 
   test "common commands basically work" do


### PR DESCRIPTION
When using MuonTrap.Daemon, waiting for files or other servers to be
available can make the code ugly. This is for programs that exit
immediately if a requirement isn't around. Coordinating these
requirements with MuonTrap.Daemon's in a supervision tree requires some
code. People using Claude are getting code added to init callbacks to
block Supervisor startup of its children which sounds fun to debug.
Rather than do all this, :wait_for lets you block however long is needed
in a function that's called in its own process. Exceptions from waiting
bubble up to whomever is supervising the MuonTrap daemon.
