### PR TITLE
Fix fork_a_lot to fork as intended

### DIFF
--- a/test/fork_a_lot.c
+++ b/test/fork_a_lot.c
@@ -22,6 +22,7 @@ static void do_fork(int left)
             do_fork(left - 1);
             // Hang out long enough to satisfy the tests
             sleep(120);
+            _exit(0);
         }
         printf("%d\n", pid);
         fflush(stdout);


### PR DESCRIPTION
It could really fork a lot due to a missing _exit in the child. This
made an experiment more interesting than it should have been when I fork
bombed myself.
