### PR TITLE
Support setting and overriding supplementary groups

### DIFF
--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -53,6 +53,7 @@ static struct option long_options[] = {
     {"set", required_argument, 0, 's'},
     {"uid", required_argument, 0, 'u'},
     {"gid", required_argument, 0, 'a'},
+    {"groups", required_argument, 0, 'G'},
     {"stdio-window", required_argument, 0, 'l'},
     {"capture-output", no_argument, 0, 'o'},
     {"capture-stderr", no_argument, 0, 'e'},
@@ -82,6 +83,16 @@ static const char *cgroup_path = NULL;
 static int brutal_kill_wait_ms = 500;
 static uid_t run_as_uid = 0; // 0 means don't set, since we don't support privilege escalation
 static gid_t run_as_gid = 0; // 0 means don't set, since we don't support privilege escalation
+static const char *run_as_user_name = NULL; // set when --uid was a name; triggers initgroups()
+static gid_t run_as_pw_gid = 0;  // primary gid from getpwnam(); used as initgroups()'s extra gid
+
+// Supplementary group handling. NGROUPS_MAX is the kernel limit (typically
+// 65536 on Linux); we cap our own buffer well below that. setgroups() requires
+// privileges, so this must be applied before setuid().
+#define MAX_SUPPLEMENTARY_GROUPS 256
+static int explicit_groups = 0;        // 1 if --groups was given (even with empty list)
+static int num_explicit_groups = 0;
+static gid_t explicit_group_ids[MAX_SUPPLEMENTARY_GROUPS];
 
 static int signal_pipe[2] = { -1, -1};
 static int stdout_pipe[2] = { -1, -1};
@@ -115,6 +126,8 @@ static void usage()
     printf("--capture-stderr-only\n");
     printf("--uid <uid/user> drop privilege to this uid or user\n");
     printf("--gid <gid/group> drop privilege to this gid or group\n");
+    printf("--groups <list> set supplementary groups (comma-separated gids/names;\n");
+    printf("                empty string drops all). Overrides initgroups().\n");
     printf("-- the program to run and its arguments come after this\n");
 }
 
@@ -217,6 +230,22 @@ static int fork_exec(const char *path, char *const *argv)
         // See https://wiki.sei.cmu.edu/confluence/display/c/POS36-C.+Observe+correct+revocation+order+while+relinquishing+privileges
         if (run_as_gid > 0 && setgid(run_as_gid) < 0)
             FATAL("setgid(%d)", run_as_gid);
+
+        // Supplementary groups must be set before setuid() drops root.
+        // Explicit --groups wins; otherwise, if --uid was a username, fall back
+        // to initgroups() so /etc/group memberships apply. A numeric --uid with
+        // no --groups leaves the parent's supplementary groups in place.
+        if (explicit_groups) {
+            if (setgroups(num_explicit_groups, explicit_group_ids) < 0)
+                FATAL("setgroups()");
+        } else if (run_as_user_name) {
+            // Pass the effective primary gid so initgroups() doesn't add the
+            // user's passwd gid as a supplementary group when --gid has
+            // overridden the primary.
+            gid_t init_gid = (run_as_gid > 0) ? run_as_gid : run_as_pw_gid;
+            if (initgroups(run_as_user_name, init_gid) < 0)
+                FATAL("initgroups(%s)", run_as_user_name);
+        }
 
         if (run_as_uid > 0 && setuid(run_as_uid) < 0)
             FATAL("setuid(%d)", run_as_uid);
@@ -734,7 +763,7 @@ int main(int argc, char *argv[])
     int opt;
     char *argv0 = NULL;
     struct controller_info *current_controller = NULL;
-    while ((opt = getopt_long(argc, argv, "a:c:g:hk:s:0:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "a:c:g:hk:s:u:G:0:", long_options, NULL)) != -1) {
         switch (opt) {
         case 'a': // --gid
         {
@@ -814,9 +843,60 @@ int main(int argc, char *argv[])
                 if (!passwd)
                     FATALX("Unknown user '%s'", optarg);
                 run_as_uid = passwd->pw_uid;
+                run_as_pw_gid = passwd->pw_gid;
+                run_as_user_name = optarg;
             }
             if (run_as_uid == 0)
                 FATALX("Setting the user to root or uid 0 is not allowed");
+            break;
+        }
+
+        case 'G': // --groups
+        {
+            explicit_groups = 1;
+            num_explicit_groups = 0;
+            // optarg is a comma-separated list of gids and/or group names.
+            // An empty string means "no supplementary groups."
+            char *list = strdup(optarg);
+            if (!list)
+                FATAL("strdup");
+            char *saveptr = NULL;
+            char *tok = strtok_r(list, ",", &saveptr);
+            while (tok) {
+                if (num_explicit_groups >= MAX_SUPPLEMENTARY_GROUPS)
+                    FATALX("Too many supplementary groups (max %d)", MAX_SUPPLEMENTARY_GROUPS);
+
+                // Treat the token as numeric only if it consists entirely of
+                // digits. This rejects signed values like "-1" that strtoul
+                // would otherwise silently wrap into a valid-looking gid.
+                int is_numeric = (*tok != '\0');
+                for (const char *p = tok; *p; p++) {
+                    if (*p < '0' || *p > '9') {
+                        is_numeric = 0;
+                        break;
+                    }
+                }
+
+                gid_t gid;
+                if (is_numeric) {
+                    errno = 0;
+                    char *endptr;
+                    unsigned long parsed = strtoul(tok, &endptr, 10);
+                    gid = (gid_t)parsed;
+                    if (errno == ERANGE || (unsigned long)gid != parsed)
+                        FATALX("Group id '%s' is out of range", tok);
+                } else {
+                    struct group *grp = getgrnam(tok);
+                    if (!grp)
+                        FATALX("Unknown group '%s'", tok);
+                    gid = grp->gr_gid;
+                }
+                if (gid == 0)
+                    FATALX("Supplementary group id 0 is not allowed");
+                explicit_group_ids[num_explicit_groups++] = gid;
+                tok = strtok_r(NULL, ",", &saveptr);
+            }
+            free(list);
             break;
         }
 

--- a/lib/muontrap.ex
+++ b/lib/muontrap.ex
@@ -59,8 +59,14 @@ defmodule MuonTrap do
     * `:cgroup_path` - explicitly specify a path to use. Use `:cgroup_base`, unless you must control the path.
     * `:cgroup_sets` - set a cgroup controller parameter before running the command
     * `:delay_to_sigkill` - milliseconds before sending a SIGKILL to a child process if it doesn't exit with a SIGTERM (default 500 ms)
-    * `:uid` - run the command using the specified uid or username
+    * `:uid` - run the command using the specified uid or username. When a
+      username is given, supplementary groups are loaded from `/etc/group`.
+      When a numeric uid is given, supplementary groups inherit from the
+      parent. See `:groups` to override.
     * `:gid` - run the command using the specified gid or group
+    * `:groups` - explicit list of supplementary group ids or names (as
+      integers or binaries). Pass `[]` to drop all supplementary groups.
+      Overrides default behavior depending on username `:uid` setting.
     * `:timeout` - milliseconds to wait for the command to complete. If the
       command does not exit before the timeout, the return value will contain
       the output up to that point and `:timeout` as the exit status. The child

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -45,6 +45,7 @@ defmodule MuonTrap.Options do
   * `:cgroup_sets`
   * `:uid`
   * `:gid`
+  * `:groups`
   * `:timeout` - `MuonTrap.cmd/3` only
 
   """
@@ -192,6 +193,30 @@ defmodule MuonTrap.Options do
 
   defp validate_option(_any, {:gid, id}, opts) when is_integer(id) or is_binary(id),
     do: Map.put(opts, :gid, id)
+
+  defp validate_option(_any, {:groups, groups}, opts) when is_list(groups) do
+    Enum.each(groups, fn
+      id when is_integer(id) and id > 0 ->
+        :ok
+
+      name when is_binary(name) ->
+        # The C helper splits --groups on commas, so a name containing a comma
+        # would silently expand into multiple entries. An empty name would
+        # likewise produce an empty token.
+        #
+        # Reject gid 0 here as well to keep supplementary group handling
+        # aligned with the existing :gid/--gid safety checks.
+        if name == "" or name == "0" or String.contains?(name, ","),
+          do: raise(ArgumentError, "invalid :groups entry: #{inspect(name)}")
+
+        :ok
+
+      bad ->
+        raise ArgumentError, "invalid :groups entry: #{inspect(bad)}"
+    end)
+
+    Map.put(opts, :groups, groups)
+  end
 
   defp validate_option(:cmd, {:timeout, timeout}, opts) when is_integer(timeout) and timeout > 0,
     do: Map.put(opts, :timeout, timeout)

--- a/lib/muontrap/port.ex
+++ b/lib/muontrap/port.ex
@@ -73,6 +73,7 @@ defmodule MuonTrap.Port do
   defp muontrap_arg({:delay_to_sigkill, delay}), do: ["--delay-to-sigkill", to_string(delay)]
   defp muontrap_arg({:uid, id}), do: ["--uid", to_string(id)]
   defp muontrap_arg({:gid, id}), do: ["--gid", to_string(id)]
+  defp muontrap_arg({:groups, groups}), do: ["--groups", Enum.map_join(groups, ",", &to_string/1)]
   defp muontrap_arg({:arg0, arg0}), do: ["--arg0", arg0]
   defp muontrap_arg({:stdio_window, count}), do: ["--stdio-window", to_string(count)]
   defp muontrap_arg({:stderr_to_stdout, true}), do: ["--capture-stderr"]

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -163,4 +163,34 @@ defmodule MuonTrap.OptionsTest do
       assert Map.get(options, :cgroup_sets) == [{"memory", "memory.limit_in_bytes", "268435456"}]
     end
   end
+
+  test "accepts :groups list of integers and binaries (including empty)" do
+    options = Options.validate(:cmd, "echo", [], groups: [10, "audio", 100])
+    assert options.groups == [10, "audio", 100]
+
+    options = Options.validate(:cmd, "echo", [], groups: [])
+    assert options.groups == []
+  end
+
+  test "rejects malformed :groups entries" do
+    assert_raise ArgumentError, ~r/invalid :groups entry/, fn ->
+      Options.validate(:cmd, "echo", [], groups: [10, -1])
+    end
+
+    assert_raise ArgumentError, ~r/invalid :groups entry/, fn ->
+      Options.validate(:cmd, "echo", [], groups: [10, :atom])
+    end
+
+    assert_raise ArgumentError, ~r/invalid :groups entry/, fn ->
+      Options.validate(:cmd, "echo", [], groups: [""])
+    end
+
+    assert_raise ArgumentError, ~r/invalid :groups entry/, fn ->
+      Options.validate(:cmd, "echo", [], groups: ["audio,video"])
+    end
+
+    assert_raise ArgumentError, ~r/invalid option :groups/, fn ->
+      Options.validate(:cmd, "echo", [], groups: "audio")
+    end
+  end
 end

--- a/test/port_test.exs
+++ b/test/port_test.exs
@@ -114,6 +114,30 @@ defmodule MuonTrapPortTest do
            ]
   end
 
+  test "handles groups" do
+    options = %{cmd: "/bin/echo", args: [], groups: [10, "audio", 100]}
+    port_options = MuonTrap.Port.port_options(options)
+
+    assert Keyword.get(port_options, :args) == [
+             "--groups",
+             "10,audio,100",
+             "--",
+             "/bin/echo"
+           ]
+  end
+
+  test "handles empty groups list" do
+    options = %{cmd: "/bin/echo", args: [], groups: []}
+    port_options = MuonTrap.Port.port_options(options)
+
+    assert Keyword.get(port_options, :args) == [
+             "--groups",
+             "",
+             "--",
+             "/bin/echo"
+           ]
+  end
+
   test "handles gid" do
     options = %{
       cmd: "/bin/echo",


### PR DESCRIPTION
Previously supplementary groups were inherited. That's still possible,
but it's more expected for them to be set based on what's in
`/etc/groups`. It's also convenient to force supplementary groups so
that's supported via the `:groups` option.
