### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 # MuonTrap
 
 [![Hex version](https://img.shields.io/hexpm/v/muontrap.svg "Hex version")](https://hex.pm/packages/muontrap)
-[![API docs](https://img.shields.io/hexpm/v/muontrap.svg?label=hexdocs "API docs")](https://hexdocs.pm/muontrap/MuonTrap.html)
+[![API docs](https://img.shields.io/hexpm/v/muontrap.svg?label=hexdocs "API docs")](https://muontrap.hexdocs.pm/MuonTrap.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/fhunleth/muontrap/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/fhunleth/muontrap/tree/main)
 [![Coverage Status](https://coveralls.io/repos/github/fhunleth/muontrap/badge.svg)](https://coveralls.io/github/fhunleth/muontrap)
 [![REUSE status](https://api.reuse.software/badge/github.com/fhunleth/muontrap)](https://api.reuse.software/info/github.com/fhunleth/muontrap)
@@ -48,7 +48,7 @@ end
 ```
 
 Run a command similar to
-[`System.cmd/3`](https://hexdocs.pm/elixir/System.html#cmd/3):
+[`System.cmd/3`](https://elixir.hexdocs.pm/System.html#cmd/3):
 
 ```elixir
 iex>  MuonTrap.cmd("echo", ["hello"])
@@ -56,7 +56,7 @@ iex>  MuonTrap.cmd("echo", ["hello"])
 ```
 
 Attach a long running process to a supervision tree using a
-[child_spec](https://hexdocs.pm/elixir/Supervisor.html#module-child-specification)
+[child_spec](https://elixir.hexdocs.pm/Supervisor.html#module-child-specification)
 like the following:
 
 ```elixir

--- a/lib/muontrap/options.ex
+++ b/lib/muontrap/options.ex
@@ -50,7 +50,7 @@ defmodule MuonTrap.Options do
   """
   @type t() :: map()
 
-  # See https://hexdocs.pm/logger/Logger.html#module-levels
+  # See https://logger.hexdocs.pm/Logger.html#module-levels
   # Include `:warn` for older Elixir versions
   @log_levels [:emergency, :alert, :critical, :error, :warning, :warn, :notice, :info, :debug]
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://muontrap.hexdocs.pm/MuonTrap.html): Status 404
⚠️ Verification finished: 3 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>