### PR TITLE
Fix :epipe exits when a command produces output

### DIFF
--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -100,6 +100,7 @@ static int stdout_pipe[2] = { -1, -1};
 static int stderr_pipe[2] = { -1, -1};
 
 #define DEFAULT_STDIO_WINDOW 10240 // Allow up to 10 KB out to Elixir at a time
+#define ACK_WAIT_TIMEOUT_MS 10000 // Max time to wait for stdio acks before exiting
 static int stdio_bytes_max = DEFAULT_STDIO_WINDOW;
 static int stdio_bytes_avail = DEFAULT_STDIO_WINDOW;
 static int capture_output = 0; // Don't capture output by default
@@ -718,6 +719,65 @@ static int process_stdio(int from_fd)
 }
 #endif
 
+// Process acknowledgments from Erlang for captured output. Returns -1 on
+// EOF, a read error, or more acks than bytes sent.
+static int process_acks()
+{
+    uint8_t acknowledgments[32];
+    ssize_t amt = read(STDIN_FILENO, acknowledgments, sizeof(acknowledgments));
+    if (amt > 0) {
+        // More than one acknowledgment may have come in, so process them all.
+        // NOTE: each ack is 1+its_value
+        int total_acks = amt;
+        for (ssize_t i = 0; i < amt; i++)
+            total_acks += acknowledgments[i];
+
+        stdio_bytes_avail += total_acks;
+        if (stdio_bytes_avail > stdio_bytes_max) {
+            WARNX("Too many acks %d/%d, got %d", (int) stdio_bytes_avail, (int) stdio_bytes_max, total_acks);
+            return -1;
+        }
+    } else if (amt == 0) {
+        INFO("eof on STDIN_FILENO");
+        return -1;
+    } else if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+        INFO("read STDIN_FILENO error: %s", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+// Wait for Erlang to acknowledge all captured output before exiting. Exiting
+// with acks in flight makes the Erlang-side write fail with EPIPE, and the
+// port kills the process that ran the command with reason :epipe.
+static void wait_for_acks()
+{
+    struct pollfd fds[1];
+    fds[0].fd = STDIN_FILENO;
+    fds[0].events = POLLIN;
+
+    while (stdio_bytes_avail < stdio_bytes_max) {
+        int rc = poll(fds, 1, ACK_WAIT_TIMEOUT_MS);
+        if (rc < 0 && errno == EINTR)
+            continue;
+
+        if (rc <= 0) {
+            // Erlang should have acknowledged by now, so give up rather than hang.
+            WARNX("gave up waiting for acks (%d/%d)", (int) stdio_bytes_avail, (int) stdio_bytes_max);
+            return;
+        }
+
+        if (fds[0].revents & POLLHUP) {
+            // Erlang closed the port, so no more acks are coming.
+            return;
+        }
+
+        if (process_acks() < 0)
+            return;
+    }
+}
+
 static int child_wait_loop(pid_t child_pid, int *still_running)
 {
     struct pollfd fds[4];
@@ -762,24 +822,8 @@ static int child_wait_loop(pid_t child_pid, int *still_running)
         }
 
         if (fds[0].revents & POLLIN) {
-            uint8_t acknowledgments[32];
-            ssize_t amt = read(STDIN_FILENO, acknowledgments, sizeof(acknowledgments));
-            if (amt >= 0) {
-                // More than one acknowledgment may have come in, so process them all.
-                // NOTE: each ack is 1+its_value
-                int total_acks = amt;
-                for (ssize_t i = 0; i < amt; i++)
-                    total_acks += acknowledgments[i];
-
-                stdio_bytes_avail += total_acks;
-                if (stdio_bytes_avail > stdio_bytes_max) {
-                    WARNX("Too many acks %d/%d, got %d", (int) stdio_bytes_avail, (int) stdio_bytes_max, total_acks);
-                    return EXIT_FAILURE;
-                }
-            } else if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-                INFO("read STDIN_FILENO error: %s", strerror(errno));
+            if (process_acks() < 0)
                 return EXIT_FAILURE;
-            }
         }
 
         if (poll_num > 2 && fds[2].revents) {
@@ -1078,5 +1122,6 @@ int main(int argc, char *argv[])
     }
     disable_signal_handlers();
 
+    wait_for_acks();
     exit(exit_status);
 }

--- a/lib/muontrap/port.ex
+++ b/lib/muontrap/port.ex
@@ -48,6 +48,12 @@ defmodule MuonTrap.Port do
       {^port, {:exit_status, status}} ->
         {acc, status}
 
+      # Port died abnormally (only received when the caller traps exits). No
+      # :exit_status will arrive, so exit with the port's reason rather than
+      # wait forever.
+      {:EXIT, ^port, reason} when reason != :normal ->
+        exit(reason)
+
       ^timeout_message ->
         Port.close(port)
         {acc, :timeout}

--- a/test/muontrap_test.exs
+++ b/test/muontrap_test.exs
@@ -122,6 +122,27 @@ defmodule MuonTrapTest do
     assert length(split) == 1001
   end
 
+  test "cmd/3 doesn't kill concurrent callers with :epipe" do
+    # Exiting while acks for captured output were in flight used to kill the
+    # caller with :epipe. The race needs scheduler load to trigger, so run
+    # many commands concurrently.
+    refs =
+      for _ <- 1..200 do
+        {_pid, ref} =
+          spawn_monitor(fn ->
+            exit(MuonTrap.cmd(test_path("print_and_exit.test"), []))
+          end)
+
+        ref
+      end
+
+    for ref <- refs do
+      assert_receive {:DOWN, ^ref, :process, _pid, result}, 30_000
+      assert {output, 0} = result
+      assert is_binary(output)
+    end
+  end
+
   test "cmd/3 with timeout" do
     opts = [timeout: 250]
 

--- a/test/print_and_exit.c
+++ b/test/print_and_exit.c
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 David Calvo
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+    int i;
+    for (i = 0; i < 1000; i++) {
+        printf("%d-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\n", i);
+    }
+    fflush(stdout);
+
+    // Exit immediately since the :epipe regression test needs
+    // acknowledgments to still be in flight
+    exit(0);
+}


### PR DESCRIPTION
When a command produces captured output, muontrap exits as soon as the child does — sometimes before reading the acknowledgments that the Erlang side writes for the final output bytes. The ack write then fails with EPIPE, and the port delivers an `:epipe` exit signal to the process that called `MuonTrap.cmd/3`, killing it. The `rescue` in `report_bytes_handled/2` only covers the synchronous `ArgumentError` case, so the asynchronous signal gets through. This is the same race that 2fbe716 handled for `MuonTrap.Daemon`, but `cmd/3` drives the port from the calling process, which usually isn't trapping exits, so it can't be handled on the Elixir side alone.

Since Erlang acknowledges every byte it receives, the fix is to wait for the outstanding acks before exiting. Once the counts match, Erlang has nothing left to write and the close can't race anything. The wait returns immediately when Erlang closes the port, and gives up after 10 seconds rather than hang if acknowledgments ever stop coming. Commands that produce no captured output exit exactly as before, since nothing is ever outstanding.

`do_cmd/4` also gets a clause for abnormal port exits: if the caller happens to trap exits and the port dies without delivering `:exit_status` (say the muontrap binary was killed), it previously waited forever because no receive clause matched. It now exits with the port's reason, like the Daemon does.

On Linux (x86_64, 80 schedulers, OTP 28), 200–250 concurrent `MuonTrap.cmd("seq", ["1", "13000"])` calls killed 2–10 callers per round with `:epipe` on main. On macOS 15 (arm64, 14 cores, OTP 27), the same workload killed 44–74 per round of 250. With this change there were no failures in 2,500 runs on Linux and 750 on macOS, and the new regression test fails on main and passes on both platforms. The C wrapper builds warning-free with gcc and clang, and `mix test --exclude cgroup` shows no regressions on either platform — the only failures were pre-existing timing flakes. I wasn't able to run the cgroup tests.

Fixes #98.