### PR TITLE
Fix truncated output when a command exits

### DIFF
--- a/c_src/muontrap.c
+++ b/c_src/muontrap.c
@@ -101,6 +101,7 @@ static int stderr_pipe[2] = { -1, -1};
 
 #define DEFAULT_STDIO_WINDOW 10240 // Allow up to 10 KB out to Elixir at a time
 #define ACK_WAIT_TIMEOUT_MS 10000 // Max time to wait for stdio acks before exiting
+#define DRAIN_TIMEOUT_MS 10000 // Max time to spend draining stdio after the child exits
 static int stdio_bytes_max = DEFAULT_STDIO_WINDOW;
 static int stdio_bytes_avail = DEFAULT_STDIO_WINDOW;
 static int capture_output = 0; // Don't capture output by default
@@ -778,6 +779,52 @@ static void wait_for_acks()
     }
 }
 
+// Forward output that the child left in the pipes.
+//
+// process_stdio() only moves as much as the flow control window allows, and
+// child_wait_loop() stops polling the output fds once that window is empty, so
+// returning when the child is reaped drops whatever is still queued. Everything
+// the child wrote is in the pipe by now, so a zero-timeout poll is enough to
+// recognize an empty one and this costs nothing when it already is. The timeout
+// only applies if something that inherited the pipe outlives the child and
+// keeps writing, since draining forever would hold up cleanup.
+static void drain_stdio()
+{
+    int drain_fds[2];
+    int num_fds = 0;
+
+    if (capture_stderr_only) {
+        drain_fds[num_fds++] = stderr_pipe[0];
+    } else if (capture_output) {
+        drain_fds[num_fds++] = stdout_pipe[0];
+        if (capture_stderr)
+            drain_fds[num_fds++] = stderr_pipe[0];
+    }
+
+    int end_timeout_us = microsecs() + (1000 * DRAIN_TIMEOUT_MS);
+    struct pollfd fds[1];
+    fds[0].events = POLLIN;
+
+    for (int i = 0; i < num_fds; i++) {
+        fds[0].fd = drain_fds[i];
+
+        while (microsecs() - end_timeout_us < 0) {
+            int rc = poll(fds, 1, 0);
+            if (rc < 0 && errno == EINTR)
+                continue;
+
+            if (rc <= 0)
+                break;
+
+            if (stdio_bytes_avail <= 0)
+                wait_for_acks();
+
+            if (stdio_bytes_avail <= 0 || process_stdio(drain_fds[i]) < 0)
+                return;
+        }
+    }
+}
+
 static int child_wait_loop(pid_t child_pid, int *still_running)
 {
     struct pollfd fds[4];
@@ -865,6 +912,8 @@ static int child_wait_loop(pid_t child_pid, int *still_running)
                         INFO("child terminated with unexpected status: %d", status);
                         exit_status = EXIT_FAILURE;
                     }
+
+                    drain_stdio();
                     return exit_status;
                 } else {
                     INFO("something else caused sigchild: pid=%d, status=%d. our child=%d", dying_pid, status, child_pid);

--- a/test/muontrap_test.exs
+++ b/test/muontrap_test.exs
@@ -122,6 +122,20 @@ defmodule MuonTrapTest do
     assert length(split) == 1001
   end
 
+  test "cmd/3 captures all output from a command that exits immediately" do
+    # Whatever the flow control window hasn't forwarded yet is still in the pipe
+    # when the child is reaped. Repeat, since losing it depends on how the exit
+    # races the output.
+    for opts <- [[], [stdio_window: 63]], _ <- 1..20 do
+      {output, 0} = MuonTrap.cmd(test_path("print_and_exit.test"), [], opts)
+
+      split =
+        String.split(output, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+      assert length(split) == 1001
+    end
+  end
+
   test "cmd/3 doesn't kill concurrent callers with :epipe" do
     # Exiting while acks for captured output were in flight used to kill the
     # caller with :epipe. The race needs scheduler load to trigger, so run


### PR DESCRIPTION
Follow-up to #98. Fixing the `:epipe` crash uncovered a second problem on the
same path: output gets dropped and nothing tells you about it. The crash was
happening first, so it hid this. I'm using MuonTrap to run commands in an agent
harness and feed the output back to a model, which has no way to tell a
truncated result from a complete one.

`process_stdio()` only forwards as much as the flow control window allows, and
`child_wait_loop()` stops polling the output fds once that window is empty. When
the child is reaped we return right away, so anything still sitting in the pipes
goes away with it. That's why what gets lost is always a whole number of
windows.

`cmd/3` just hands back a short binary with a 0 exit status, so there's nothing
to key off of. Two commands, 40 runs each:

- `print_and_exit.test`, 66890 bytes: 0/40 runs came back complete, worst case
  kept 10240 bytes
- `seq 1 100000`, 588895 bytes: 24/40 complete, worst case kept 542720 bytes

The child's writes have all finished by the time it exits, so draining the pipes
before returning is enough. Polling with a 0 timeout tells us when a pipe is
empty, so the usual case costs one extra syscall. If the window is empty I wait
on acks the same way the exit path already does.

The test I added fails at 461/1001 lines without the C change. Related:
`test/print_a_lot.c` has had a `sleep(1)` in it since flow control landed in
d3d0336, commented "muontrap doesn't wait for all output to be consumed". That
sleep is why the existing "prints a lot" tests pass, so I left it alone and used
`print_and_exit.test` instead.

Only tested on aarch64 Linux, so the `splice()` branch. The read/write fallback
goes through the same drain loop but I have no way to run it here. cgroup tests
are excluded since I didn't set up the `muontrap_test` cgroup; the rest pass.
